### PR TITLE
[CARA-19] feat: Add caractl logs command with agent log streaming endpoint

### DIFF
--- a/cmd/cara-agent/main.go
+++ b/cmd/cara-agent/main.go
@@ -14,6 +14,7 @@ import (
 	"NYCU-SDC/caravanserai/internal/agent"
 	agentapiserver "NYCU-SDC/caravanserai/internal/agent/apiserver"
 	forwardhandler "NYCU-SDC/caravanserai/internal/agent/apiserver/handler/forward"
+	logshandler "NYCU-SDC/caravanserai/internal/agent/apiserver/handler/logs"
 	"NYCU-SDC/caravanserai/internal/agent/docker"
 	"NYCU-SDC/caravanserai/internal/agent/proxy"
 	"NYCU-SDC/caravanserai/internal/appinit"
@@ -110,8 +111,12 @@ func main() {
 
 	// ── Agent HTTP server ────────────────────────────────────────────────
 	apiSrv := agentapiserver.New(logger)
-	problemWriter := problem.NewWithMapping(forwardhandler.NewProblemMapping())
-	apiSrv.Register(forwardhandler.NewHandler(logger, dockerRuntime, problemWriter))
+
+	forwardPW := problem.NewWithMapping(forwardhandler.NewProblemMapping())
+	apiSrv.Register(forwardhandler.NewHandler(logger, dockerRuntime, forwardPW))
+
+	logsPW := problem.NewWithMapping(logshandler.NewProblemMapping())
+	apiSrv.Register(logshandler.NewHandler(logger, dockerRuntime, logsPW))
 
 	httpServer := &http.Server{
 		Addr:    net.JoinHostPort("0.0.0.0", cfg.ListenPort),

--- a/cmd/caractl/main.go
+++ b/cmd/caractl/main.go
@@ -41,6 +41,7 @@ func init() {
 	rootCmd.AddCommand(cli.NewDeleteCmd())
 	rootCmd.AddCommand(cli.NewApplyCmd())
 	rootCmd.AddCommand(cli.NewPortForwardCmd())
+	rootCmd.AddCommand(cli.NewLogsCmd())
 }
 
 func main() {

--- a/internal/agent/apiserver/handler/logs/handler.go
+++ b/internal/agent/apiserver/handler/logs/handler.go
@@ -1,0 +1,202 @@
+// Package logs provides the chunked HTTP log streaming endpoint.
+//
+// Routes:
+//
+//	GET /api/v1/logs/{project}/{service} — stream container logs
+package logs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"NYCU-SDC/caravanserai/internal/agent/docker"
+
+	"github.com/NYCU-SDC/summer/pkg/problem"
+	"github.com/docker/docker/pkg/stdcopy"
+	"go.uber.org/zap"
+)
+
+// Sentinel errors for container-level problems.  These are mapped to HTTP
+// status codes by NewProblemMapping.
+var (
+	// ErrContainerNotFound indicates the requested container does not exist.
+	ErrContainerNotFound = errors.New("container not found")
+	// ErrContainerNotRunning indicates the container exists but is stopped
+	// (only relevant when follow=true).
+	ErrContainerNotRunning = errors.New("container not running")
+)
+
+// NewProblemMapping returns the error→Problem mapping for the logs handler.
+// Pass the result to problem.NewWithMapping.
+func NewProblemMapping() func(error) problem.Problem {
+	return func(err error) problem.Problem {
+		switch {
+		case errors.Is(err, ErrContainerNotFound):
+			return problem.NewNotFoundProblem(err.Error())
+
+		case errors.Is(err, ErrContainerNotRunning):
+			return problem.Problem{
+				Title:  "Conflict",
+				Status: http.StatusConflict,
+				Type:   "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409",
+				Detail: err.Error(),
+			}
+
+		default:
+			return problem.Problem{} // fall through to summer built-in
+		}
+	}
+}
+
+// ContainerLogger is the narrow interface the logs handler needs to stream
+// container logs.
+type ContainerLogger interface {
+	// ContainerLogs returns a streaming reader of the container logs for the
+	// given project and service.
+	ContainerLogs(ctx context.Context, project, service string, follow bool, tail string, timestamps bool) (docker.ContainerLogResult, error)
+}
+
+// Handler serves the chunked HTTP container log streaming endpoint.
+type Handler struct {
+	logger        *zap.Logger
+	runtime       ContainerLogger
+	problemWriter *problem.HttpWriter
+}
+
+// NewHandler creates a Handler.
+func NewHandler(logger *zap.Logger, runtime ContainerLogger, pw *problem.HttpWriter) *Handler {
+	return &Handler{
+		logger:        logger,
+		runtime:       runtime,
+		problemWriter: pw,
+	}
+}
+
+// RegisterRoutes mounts the logs endpoint onto the mux.
+func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/logs/{project}/{service}", h.streamLogs)
+}
+
+func (h *Handler) streamLogs(w http.ResponseWriter, r *http.Request) {
+	project := r.PathValue("project")
+	service := r.PathValue("service")
+
+	log := h.logger.With(
+		zap.String("project", project),
+		zap.String("service", service),
+	)
+
+	// Parse query parameters.
+	follow := parseBool(r.URL.Query().Get("follow"), false)
+	tail := r.URL.Query().Get("tail")
+	if tail == "" {
+		tail = "all"
+	}
+	timestamps := parseBool(r.URL.Query().Get("timestamps"), false)
+
+	result, err := h.runtime.ContainerLogs(r.Context(), project, service, follow, tail, timestamps)
+	if err != nil {
+		log.Warn("Container logs failed", zap.Error(err))
+
+		// Determine the sentinel error to use.
+		sentinel := classifyError(err)
+		h.problemWriter.WriteError(r.Context(), w,
+			fmt.Errorf("container %s/%s: %w", project, service, sentinel), log)
+		return
+	}
+	defer func() { _ = result.Reader.Close() }()
+
+	// Set headers for chunked streaming.
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Transfer-Encoding", "chunked")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusOK)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		log.Error("ResponseWriter does not support Flusher")
+		return
+	}
+
+	log.Info("Streaming container logs",
+		zap.Bool("follow", follow),
+		zap.String("tail", tail),
+		zap.Bool("tty", result.TTY),
+	)
+
+	// Stream logs to the HTTP response.
+	if result.TTY {
+		// TTY containers produce a raw stream — copy directly.
+		_, _ = io.Copy(newFlushWriter(w, flusher), result.Reader)
+	} else {
+		// Non-TTY containers produce a multiplexed stream with 8-byte
+		// headers.  Demultiplex stdout+stderr into the response.
+		_, _ = stdcopy.StdCopy(newFlushWriter(w, flusher), newFlushWriter(w, flusher), result.Reader)
+	}
+
+	log.Info("Log stream closed")
+}
+
+// classifyError maps a runtime error to the appropriate sentinel error.
+func classifyError(err error) error {
+	msg := err.Error()
+	// The DockerRuntime returns "container X is not running" for follow on
+	// stopped containers, and Docker's "not found" for missing containers.
+	if containsAny(msg, "not found", "No such") {
+		return ErrContainerNotFound
+	}
+	if containsAny(msg, "not running") {
+		return ErrContainerNotRunning
+	}
+	return ErrContainerNotFound // default to not-found for unknown errors
+}
+
+// containsAny reports whether s contains any of the given substrings.
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if len(s) >= len(sub) {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// parseBool parses a query parameter as a boolean, returning the default if
+// the value is empty or unparseable.
+func parseBool(s string, defaultVal bool) bool {
+	if s == "" {
+		return defaultVal
+	}
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return defaultVal
+	}
+	return v
+}
+
+// flushWriter wraps an http.ResponseWriter and flushes after every Write.
+type flushWriter struct {
+	w       io.Writer
+	flusher http.Flusher
+}
+
+func newFlushWriter(w io.Writer, f http.Flusher) *flushWriter {
+	return &flushWriter{w: w, flusher: f}
+}
+
+func (fw *flushWriter) Write(p []byte) (int, error) {
+	n, err := fw.w.Write(p)
+	fw.flusher.Flush()
+	return n, err
+}
+
+// Ensure DockerRuntime implements ContainerLogger at compile time.
+var _ ContainerLogger = (*docker.DockerRuntime)(nil)

--- a/internal/agent/docker/client.go
+++ b/internal/agent/docker/client.go
@@ -344,6 +344,56 @@ func (r *DockerRuntime) ensureContainer(ctx context.Context, projectName string,
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+// ContainerLogResult holds a log stream from a Docker container together with
+// its TTY flag, which the caller needs to decide whether to demultiplex the
+// stream (non-TTY containers use Docker's 8-byte header framing).
+type ContainerLogResult struct {
+	// Reader is the raw log stream.  The caller must close it.
+	Reader io.ReadCloser
+	// TTY is true when the container was started with a pseudo-terminal.
+	// When false the stream is multiplexed (stdout + stderr with 8-byte
+	// headers) and must be processed with stdcopy.StdCopy.
+	TTY bool
+}
+
+// ContainerLogs returns a streaming reader of the container logs for the
+// given project/service pair.  It satisfies the narrow ContainerLogger
+// interface consumed by the logs handler.
+//
+// If the container does not exist an error wrapping isNotFound is returned.
+// If the container exists but is not running an error is still returned so
+// the handler can map it to the appropriate HTTP status.
+func (r *DockerRuntime) ContainerLogs(ctx context.Context, project, service string, follow bool, tail string, timestamps bool) (ContainerLogResult, error) {
+	cName := ContainerName(project, service)
+
+	// Inspect to verify the container exists and check its TTY flag.
+	info, err := r.client.ContainerInspect(ctx, cName)
+	if err != nil {
+		if isNotFound(err) {
+			return ContainerLogResult{}, fmt.Errorf("container %q: %w", cName, err)
+		}
+		return ContainerLogResult{}, fmt.Errorf("inspect container %q: %w", cName, err)
+	}
+
+	if !info.State.Running && follow {
+		// For follow mode, the container must be running.
+		return ContainerLogResult{}, fmt.Errorf("container %q is not running", cName)
+	}
+
+	rc, err := r.client.ContainerLogs(ctx, cName, container.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Follow:     follow,
+		Tail:       tail,
+		Timestamps: timestamps,
+	})
+	if err != nil {
+		return ContainerLogResult{}, fmt.Errorf("container logs %q: %w", cName, err)
+	}
+
+	return ContainerLogResult{Reader: rc, TTY: info.Config.Tty}, nil
+}
+
 // InspectContainer returns the running state and bridge-network IP of the
 // container for the given project/service pair.  It satisfies the narrow
 // ContainerInspector interface consumed by the forward handler.

--- a/internal/cli/cmd_logs.go
+++ b/internal/cli/cmd_logs.go
@@ -1,0 +1,160 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+// NewLogsCmd returns the "logs" command.
+//
+// Usage:
+//
+//	caractrl logs <project>/<service> [--follow] [--tail N] [--timestamps] [--node <agentAddr>]
+func NewLogsCmd() *cobra.Command {
+	var (
+		nodeAddr   string
+		follow     bool
+		tail       string
+		timestamps bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "logs <project>/<service>",
+		Short: "Print the logs of a container on a remote Node",
+		Long: `Print the logs of a container running on a remote Node via the Agent's
+log streaming endpoint.  This works similarly to kubectl logs.
+
+Examples:
+  # Print all logs from the "web" service in project "my-app"
+  caractrl logs my-app/web
+
+  # Stream logs in real-time (like tail -f)
+  caractrl logs my-app/web --follow
+
+  # Show only the last 100 lines
+  caractrl logs my-app/web --tail 100
+
+  # Show timestamps with each log line
+  caractl logs my-app/web --timestamps
+
+  # Specify Agent by node name (resolved via server API)
+  caractrl logs my-app/web --node main
+
+  # Specify Agent address explicitly
+  caractrl logs my-app/web --node 192.168.1.100:9090`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLogs(cmd, args, nodeAddr, follow, tail, timestamps)
+		},
+	}
+
+	cmd.Flags().StringVar(&nodeAddr, "node", "", "Node name or agent address (host:port); auto-resolved from server if omitted")
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Stream logs in real-time (follow)")
+	cmd.Flags().StringVar(&tail, "tail", "all", "Number of lines to show from the end of the logs (default \"all\")")
+	cmd.Flags().BoolVar(&timestamps, "timestamps", false, "Show timestamps with each log line")
+
+	return cmd
+}
+
+func runLogs(cmd *cobra.Command, args []string, nodeAddr string, follow bool, tail string, timestamps bool) error {
+	// Parse <project>/<service>
+	parts := strings.SplitN(args[0], "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("invalid target %q: expected <project>/<service>", args[0])
+	}
+	project, service := parts[0], parts[1]
+
+	// Resolve agent address (same pattern as port-forward).
+	if nodeAddr == "" {
+		// Auto-resolve from project's nodeRef.
+		serverURL, _ := cmd.Root().PersistentFlags().GetString("server")
+		resolved, resolveErr := resolveAgentAddr(serverURL, project)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		nodeAddr = resolved
+	} else if !strings.Contains(nodeAddr, ":") {
+		// Treat as a node name — resolve via the server API.
+		serverURL, _ := cmd.Root().PersistentFlags().GetString("server")
+		resolved, resolveErr := resolveNodeAddr(serverURL, nodeAddr)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		nodeAddr = resolved
+	}
+	// else: treat as raw host:port
+
+	// Set up signal handling for graceful shutdown.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// Build the request URL.
+	query := url.Values{}
+	if follow {
+		query.Set("follow", "true")
+	}
+	if tail != "all" && tail != "" {
+		query.Set("tail", tail)
+	}
+	if timestamps {
+		query.Set("timestamps", "true")
+	}
+
+	reqURL := fmt.Sprintf("http://%s/api/v1/logs/%s/%s", nodeAddr, project, service)
+	if encoded := query.Encode(); encoded != "" {
+		reqURL += "?" + encoded
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			// User cancelled with Ctrl+C.
+			return nil
+		}
+		return fmt.Errorf("request to agent: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("%s", extractLogsProblemDetail(body, resp.Status))
+	}
+
+	// Stream the response body to stdout.
+	_, err = io.Copy(os.Stdout, resp.Body)
+	if err != nil && ctx.Err() != nil {
+		// Context cancelled (Ctrl+C) — not an error.
+		return nil
+	}
+	return err
+}
+
+// extractLogsProblemDetail attempts to parse an RFC 7807 problem+json body and
+// return the human-readable detail field.  Falls back to the raw body if
+// parsing fails.
+func extractLogsProblemDetail(body []byte, httpStatus string) string {
+	var p struct {
+		Detail string `json:"detail"`
+		Title  string `json:"title"`
+	}
+	if err := json.Unmarshal(body, &p); err == nil && p.Detail != "" {
+		return p.Detail
+	}
+	// Fallback: return raw body with HTTP status.
+	return fmt.Sprintf("%s: %s", httpStatus, strings.TrimSpace(string(body)))
+}


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add container log streaming via `caractl logs` command
- Resolve issue CARA-19

This PR adds end-to-end container log streaming support to Caravanserai, following the same architecture as the existing port-forward feature (CARA-14).

### Changes

**1. Docker runtime method** (`internal/agent/docker/client.go`)
- New `ContainerLogs` method on `DockerRuntime` that streams logs from a project/service container
- Returns a `ContainerLogResult` containing the log stream and a TTY flag for demux decisions
- Supports `follow`, `tail`, and `timestamps` options via Docker SDK
- Inspects the container first to check existence, running state, and TTY mode

**2. Agent log streaming endpoint** (`internal/agent/apiserver/handler/logs/handler.go`)
- Route: `GET /api/v1/logs/{project}/{service}`
- Query params: `follow` (bool), `tail` (string), `timestamps` (bool)
- Narrow `ContainerLogger` interface with compile-time check (consumer-side pattern)
- Chunked HTTP streaming with `http.Flusher` — simpler than WebSocket for uni-directional log output
- Conditional demux: uses `stdcopy.StdCopy` for non-TTY containers, direct `io.Copy` for TTY
- Sentinel errors: `ErrContainerNotFound` → 404, `ErrContainerNotRunning` → 409

**3. CLI command** (`internal/cli/cmd_logs.go`)
- Usage: `caractl logs <project>/<service> [--follow] [--tail N] [--timestamps] [--node <addr>]`
- Reuses agent address resolution from port-forward (resolveAgentAddr/resolveNodeAddr)
- Streams HTTP response body to stdout; graceful Ctrl+C handling via signal.NotifyContext

**4. Wiring**
- Agent: registered logs handler in `cmd/cara-agent/main.go`
- CLI: registered logs command in `cmd/caractl/main.go`

## Additional Information

- **Streaming transport**: Chunked HTTP was chosen over WebSocket since log streaming is uni-directional (server → client). This is simpler and avoids the WebSocket upgrade overhead.
- **TTY detection**: The handler inspects the container's TTY flag to decide whether to demux the Docker log stream. Non-TTY containers use Docker's 8-byte multiplexed framing; TTY containers produce raw output.
- **No server-side proxy**: The CLI connects directly to the agent (same pattern as port-forward) rather than proxying through cara-server.