### PR TITLE
[CARA-20] feat: Add apply update support with PUT endpoints and create-or-update CLI

### DIFF
--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -89,13 +89,20 @@ func (c *Client) DeleteNode(ctx context.Context, name string) error {
 	return checkStatus(resp)
 }
 
+// ApplyResult wraps the resource returned by an apply operation together with
+// whether it was newly created or updated (configured).
+type ApplyResult struct {
+	Resource any
+	Created  bool // true = POST created; false = PUT updated
+}
+
 // ApplyResource submits a raw YAML/JSON manifest to the server.
 // The kind field in the manifest is used to route to the correct endpoint.
-func (c *Client) ApplyResource(ctx context.Context, raw []byte) (any, error) {
+func (c *Client) ApplyResource(ctx context.Context, raw []byte) (ApplyResult, error) {
 	// Decode just the TypeMeta to determine which endpoint to call.
 	var meta v1.TypeMeta
 	if err := json.Unmarshal(raw, &meta); err != nil {
-		return nil, fmt.Errorf("decode kind: %w", err)
+		return ApplyResult{}, fmt.Errorf("decode kind: %w", err)
 	}
 
 	switch meta.Kind {
@@ -104,34 +111,72 @@ func (c *Client) ApplyResource(ctx context.Context, raw []byte) (any, error) {
 	case "Project":
 		return c.applyProject(ctx, raw)
 	default:
-		return nil, fmt.Errorf("unsupported kind %q", meta.Kind)
+		return ApplyResult{}, fmt.Errorf("unsupported kind %q", meta.Kind)
 	}
 }
 
-// applyNode posts a Node manifest. It creates the node if it does not exist.
-func (c *Client) applyNode(ctx context.Context, raw []byte) (v1.Node, error) {
+// applyNode creates or updates a Node manifest. It tries POST first; on 409
+// Conflict it falls back to PUT to update the existing resource.
+func (c *Client) applyNode(ctx context.Context, raw []byte) (ApplyResult, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/api/v1/nodes",
 		bytes.NewReader(raw))
 	if err != nil {
-		return v1.Node{}, fmt.Errorf("build request: %w", err)
+		return ApplyResult{}, fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return v1.Node{}, fmt.Errorf("request failed: %w", err)
+		return ApplyResult{}, fmt.Errorf("request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
+	// On 409, fall back to PUT for update.
+	if resp.StatusCode == http.StatusConflict {
+		_ = resp.Body.Close()
+
+		var meta struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+		}
+		if err := json.Unmarshal(raw, &meta); err != nil {
+			return ApplyResult{}, fmt.Errorf("decode name for update: %w", err)
+		}
+
+		putReq, err := http.NewRequestWithContext(ctx, http.MethodPut,
+			c.BaseURL+"/api/v1/nodes/"+meta.Metadata.Name, bytes.NewReader(raw))
+		if err != nil {
+			return ApplyResult{}, fmt.Errorf("build PUT request: %w", err)
+		}
+		putReq.Header.Set("Content-Type", "application/json")
+
+		putResp, err := c.HTTPClient.Do(putReq)
+		if err != nil {
+			return ApplyResult{}, fmt.Errorf("PUT request failed: %w", err)
+		}
+		defer putResp.Body.Close()
+
+		if err := checkStatus(putResp); err != nil {
+			return ApplyResult{}, err
+		}
+
+		var node v1.Node
+		if err := json.NewDecoder(putResp.Body).Decode(&node); err != nil {
+			return ApplyResult{}, fmt.Errorf("decode response: %w", err)
+		}
+		return ApplyResult{Resource: node, Created: false}, nil
+	}
+
 	if err := checkStatus(resp); err != nil {
-		return v1.Node{}, err
+		return ApplyResult{}, err
 	}
 
 	var node v1.Node
 	if err := json.NewDecoder(resp.Body).Decode(&node); err != nil {
-		return v1.Node{}, fmt.Errorf("decode response: %w", err)
+		return ApplyResult{}, fmt.Errorf("decode response: %w", err)
 	}
-	return node, nil
+	return ApplyResult{Resource: node, Created: true}, nil
 }
 
 // GetProjects fetches projects from the server. If phase is non-empty, only
@@ -210,30 +255,68 @@ func (c *Client) DeleteProject(ctx context.Context, name string) (deleted bool, 
 	return resp.StatusCode == http.StatusNoContent, nil
 }
 
-// applyProject posts a Project manifest to the server.
-func (c *Client) applyProject(ctx context.Context, raw []byte) (v1.Project, error) {
+// applyProject creates or updates a Project manifest. It tries POST first; on 409
+// Conflict it falls back to PUT to update the existing resource.
+func (c *Client) applyProject(ctx context.Context, raw []byte) (ApplyResult, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/api/v1/projects",
 		bytes.NewReader(raw))
 	if err != nil {
-		return v1.Project{}, fmt.Errorf("build request: %w", err)
+		return ApplyResult{}, fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return v1.Project{}, fmt.Errorf("request failed: %w", err)
+		return ApplyResult{}, fmt.Errorf("request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
+	// On 409, fall back to PUT for update.
+	if resp.StatusCode == http.StatusConflict {
+		_ = resp.Body.Close()
+
+		var meta struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+		}
+		if err := json.Unmarshal(raw, &meta); err != nil {
+			return ApplyResult{}, fmt.Errorf("decode name for update: %w", err)
+		}
+
+		putReq, err := http.NewRequestWithContext(ctx, http.MethodPut,
+			c.BaseURL+"/api/v1/projects/"+meta.Metadata.Name, bytes.NewReader(raw))
+		if err != nil {
+			return ApplyResult{}, fmt.Errorf("build PUT request: %w", err)
+		}
+		putReq.Header.Set("Content-Type", "application/json")
+
+		putResp, err := c.HTTPClient.Do(putReq)
+		if err != nil {
+			return ApplyResult{}, fmt.Errorf("PUT request failed: %w", err)
+		}
+		defer putResp.Body.Close()
+
+		if err := checkStatus(putResp); err != nil {
+			return ApplyResult{}, err
+		}
+
+		var project v1.Project
+		if err := json.NewDecoder(putResp.Body).Decode(&project); err != nil {
+			return ApplyResult{}, fmt.Errorf("decode response: %w", err)
+		}
+		return ApplyResult{Resource: project, Created: false}, nil
+	}
+
 	if err := checkStatus(resp); err != nil {
-		return v1.Project{}, err
+		return ApplyResult{}, err
 	}
 
 	var project v1.Project
 	if err := json.NewDecoder(resp.Body).Decode(&project); err != nil {
-		return v1.Project{}, fmt.Errorf("decode response: %w", err)
+		return ApplyResult{}, fmt.Errorf("decode response: %w", err)
 	}
-	return project, nil
+	return ApplyResult{Resource: project, Created: true}, nil
 }
 
 // checkStatus returns an error if the HTTP response indicates a failure.

--- a/internal/cli/cmd_apply.go
+++ b/internal/cli/cmd_apply.go
@@ -61,7 +61,7 @@ Examples:
 				printApplyConfirmation(cmd, result)
 				return nil
 			}
-			return printer.PrintAny(result)
+			return printer.PrintAny(result.Resource)
 		},
 	}
 
@@ -118,12 +118,17 @@ func normaliseYAMLNode(v any) any {
 }
 
 // printApplyConfirmation prints a short human-readable success line.
-func printApplyConfirmation(cmd *cobra.Command, result any) {
-	switch res := result.(type) {
+func printApplyConfirmation(cmd *cobra.Command, result ApplyResult) {
+	verb := "configured"
+	if result.Created {
+		verb = "created"
+	}
+
+	switch res := result.Resource.(type) {
 	case v1.Node:
-		fmt.Fprintf(cmd.OutOrStdout(), "node/%s created\n", res.Name)
+		fmt.Fprintf(cmd.OutOrStdout(), "node/%s %s\n", res.Name, verb)
 	case v1.Project:
-		fmt.Fprintf(cmd.OutOrStdout(), "project/%s created\n", res.Name)
+		fmt.Fprintf(cmd.OutOrStdout(), "project/%s %s\n", res.Name, verb)
 	default:
 		fmt.Fprintln(cmd.OutOrStdout(), "resource applied")
 	}

--- a/internal/server/handler/errors.go
+++ b/internal/server/handler/errors.go
@@ -14,8 +14,9 @@ import (
 // to problem.NewWithMapping to create an HttpWriter.
 //
 // Mapped errors:
-//   - store.ErrNotFound     → 404 Not Found
-//   - store.ErrAlreadyExists → 409 Conflict
+//   - store.ErrNotFound       → 404 Not Found
+//   - store.ErrAlreadyExists  → 409 Conflict
+//   - store.ErrConflictState  → 409 Conflict
 //
 // Unrecognised errors return an empty Problem{}, which lets summer's built-in
 // fallback logic handle them (typically producing a 500 Internal Server Error).
@@ -26,6 +27,14 @@ func NewProblemMapping() func(error) problem.Problem {
 			return problem.NewNotFoundProblem(err.Error())
 
 		case errors.Is(err, store.ErrAlreadyExists):
+			return problem.Problem{
+				Title:  "Conflict",
+				Status: 409,
+				Type:   "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409",
+				Detail: err.Error(),
+			}
+
+		case errors.Is(err, store.ErrConflictState):
 			return problem.Problem{
 				Title:  "Conflict",
 				Status: 409,

--- a/internal/server/handler/node/handler.go
+++ b/internal/server/handler/node/handler.go
@@ -3,6 +3,7 @@
 // Routes registered:
 //
 //	POST   /api/v1/nodes                   — register / create a Node
+//	PUT    /api/v1/nodes/{name}            — update a Node's spec
 //	GET    /api/v1/nodes                   — list all Nodes
 //	GET    /api/v1/nodes/{name}            — get a single Node
 //	DELETE /api/v1/nodes/{name}            — delete a Node
@@ -58,6 +59,7 @@ func NewHandler(logger *zap.Logger, s store.NodeStore, ps ProjectLister, pw *pro
 // RegisterRoutes satisfies apiserver.RouteRegistrar.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux, mid *middleware.Set) {
 	mux.HandleFunc("POST /api/v1/nodes", mid.HandlerFunc(h.createNode))
+	mux.HandleFunc("PUT /api/v1/nodes/{name}", mid.HandlerFunc(h.updateNode))
 	mux.HandleFunc("GET /api/v1/nodes", mid.HandlerFunc(h.listNodes))
 	mux.HandleFunc("GET /api/v1/nodes/{name}", mid.HandlerFunc(h.getNode))
 	mux.HandleFunc("DELETE /api/v1/nodes/{name}", mid.HandlerFunc(h.deleteNode))
@@ -109,6 +111,52 @@ func (h *Handler) createNode(w http.ResponseWriter, r *http.Request) {
 
 	node.TypeMeta = v1.TypeMeta{APIVersion: v1.APIVersion, Kind: "Node"}
 	handlerutil.WriteJSONResponse(w, http.StatusCreated, &node)
+}
+
+func (h *Handler) updateNode(w http.ResponseWriter, r *http.Request) {
+	traceCtx, span := h.tracer.Start(r.Context(), "updateNode")
+	defer span.End()
+	logger := logutil.WithContext(traceCtx, h.logger)
+
+	name := r.PathValue("name")
+
+	var node v1.Node
+	if err := json.NewDecoder(r.Body).Decode(&node); err != nil {
+		h.problemWriter.WriteError(traceCtx, w,
+			handlerutil.NewValidationError("body", nil, "invalid request body: "+err.Error()), logger)
+		return
+	}
+
+	// Reject requests where the body name does not match the URL path.
+	if node.Name != "" && node.Name != name {
+		h.problemWriter.WriteError(traceCtx, w,
+			handlerutil.NewValidationError("metadata.name", node.Name,
+				fmt.Sprintf("metadata.name %q does not match URL path %q", node.Name, name)), logger)
+		return
+	}
+	node.Name = name
+
+	// TODO: add metadata.resourceVersion / optimistic concurrency in a future PR.
+
+	if err := h.store.UpdateNodeSpec(traceCtx, &node); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			h.problemWriter.WriteError(traceCtx, w,
+				fmt.Errorf("node not found: %s: %w", name, store.ErrNotFound), logger)
+			return
+		}
+		logger.Error("UpdateNodeSpec failed", zap.String("name", name), zap.Error(err))
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+
+	// Fetch the updated resource to return the full object (including status).
+	updated, err := h.store.GetNode(traceCtx, name)
+	if err != nil {
+		logger.Error("GetNode failed after update", zap.String("name", name), zap.Error(err))
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+	handlerutil.WriteJSONResponse(w, http.StatusOK, updated)
 }
 
 func (h *Handler) listNodes(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handler/project/handler.go
+++ b/internal/server/handler/project/handler.go
@@ -3,6 +3,7 @@
 // Routes registered:
 //
 //	POST   /api/v1/projects                  — create a Project
+//	PUT    /api/v1/projects/{name}           — update a Project's spec
 //	GET    /api/v1/projects                  — list Projects (supports ?phase= and ?nodeRef= filters)
 //	GET    /api/v1/projects/{name}           — get a single Project
 //	DELETE /api/v1/projects/{name}           — delete a Project
@@ -49,6 +50,7 @@ func NewHandler(logger *zap.Logger, s store.ProjectStore, pw *problem.HttpWriter
 // RegisterRoutes satisfies apiserver.RouteRegistrar.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux, mid *middleware.Set) {
 	mux.HandleFunc("POST /api/v1/projects", mid.HandlerFunc(h.createProject))
+	mux.HandleFunc("PUT /api/v1/projects/{name}", mid.HandlerFunc(h.updateProject))
 	mux.HandleFunc("GET /api/v1/projects", mid.HandlerFunc(h.listProjects))
 	mux.HandleFunc("GET /api/v1/projects/{name}", mid.HandlerFunc(h.getProject))
 	mux.HandleFunc("DELETE /api/v1/projects/{name}", mid.HandlerFunc(h.deleteProject))
@@ -56,6 +58,58 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux, mid *middleware.Set) {
 }
 
 // ── handlers ──────────────────────────────────────────────────────────────────
+
+// validateProjectSpec validates the project spec, returning a handlerutil.ValidationError
+// if any rule is violated, or nil if the spec is valid.
+func validateProjectSpec(spec v1.ProjectSpec) error {
+	if len(spec.Services) == 0 {
+		return handlerutil.NewValidationError("spec.services", nil, "spec.services must contain at least one service")
+	}
+	for _, svc := range spec.Services {
+		if svc.Name == "" {
+			return handlerutil.NewValidationError("spec.services[].name", nil, "each service must have a non-empty name")
+		}
+		if svc.Image == "" {
+			return handlerutil.NewValidationError("spec.services[].image", svc.Name, "service "+svc.Name+": image is required")
+		}
+	}
+
+	if len(spec.Ingress) > 0 {
+		serviceNames := make(map[string]bool, len(spec.Services))
+		for _, svc := range spec.Services {
+			serviceNames[svc.Name] = true
+		}
+
+		ingressNames := make(map[string]bool, len(spec.Ingress))
+		for _, ing := range spec.Ingress {
+			if ing.Name == "" {
+				return handlerutil.NewValidationError("spec.ingress[].name", nil, "each ingress entry must have a non-empty name")
+			}
+
+			if ingressNames[ing.Name] {
+				return handlerutil.NewValidationError("spec.ingress[].name", ing.Name, "duplicate ingress name: "+ing.Name)
+			}
+			ingressNames[ing.Name] = true
+
+			if !serviceNames[ing.Target.Service] {
+				return handlerutil.NewValidationError("spec.ingress[].target.service", ing.Target.Service,
+					"ingress "+ing.Name+": target service "+ing.Target.Service+" does not exist in spec.services")
+			}
+
+			if ing.Target.Port <= 0 {
+				return handlerutil.NewValidationError("spec.ingress[].target.port", ing.Target.Port,
+					fmt.Sprintf("ingress %s: target port must be greater than 0", ing.Name))
+			}
+
+			if ing.Access.Scope != "" && ing.Access.Scope != v1.IngressScopeInternal {
+				return handlerutil.NewValidationError("spec.ingress[].access.scope", ing.Access.Scope,
+					"ingress "+ing.Name+": only \"Internal\" scope is supported")
+			}
+		}
+	}
+
+	return nil
+}
 
 func (h *Handler) createProject(w http.ResponseWriter, r *http.Request) {
 	traceCtx, span := h.tracer.Start(r.Context(), "createProject")
@@ -81,69 +135,9 @@ func (h *Handler) createProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate spec: at least one service with a non-empty image is required.
-	if len(project.Spec.Services) == 0 {
-		h.problemWriter.WriteError(traceCtx, w,
-			handlerutil.NewValidationError("spec.services", nil, "spec.services must contain at least one service"), logger)
+	if err := validateProjectSpec(project.Spec); err != nil {
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
 		return
-	}
-	for _, svc := range project.Spec.Services {
-		if svc.Name == "" {
-			h.problemWriter.WriteError(traceCtx, w,
-				handlerutil.NewValidationError("spec.services[].name", nil, "each service must have a non-empty name"), logger)
-			return
-		}
-		if svc.Image == "" {
-			h.problemWriter.WriteError(traceCtx, w,
-				handlerutil.NewValidationError("spec.services[].image", svc.Name, "service "+svc.Name+": image is required"), logger)
-			return
-		}
-	}
-
-	// Validate ingress rules (if present).
-	if len(project.Spec.Ingress) > 0 {
-		// Build a set of valid service names for target reference validation.
-		serviceNames := make(map[string]bool, len(project.Spec.Services))
-		for _, svc := range project.Spec.Services {
-			serviceNames[svc.Name] = true
-		}
-
-		ingressNames := make(map[string]bool, len(project.Spec.Ingress))
-		for _, ing := range project.Spec.Ingress {
-			if ing.Name == "" {
-				h.problemWriter.WriteError(traceCtx, w,
-					handlerutil.NewValidationError("spec.ingress[].name", nil, "each ingress entry must have a non-empty name"), logger)
-				return
-			}
-
-			if ingressNames[ing.Name] {
-				h.problemWriter.WriteError(traceCtx, w,
-					handlerutil.NewValidationError("spec.ingress[].name", ing.Name, "duplicate ingress name: "+ing.Name), logger)
-				return
-			}
-			ingressNames[ing.Name] = true
-
-			if !serviceNames[ing.Target.Service] {
-				h.problemWriter.WriteError(traceCtx, w,
-					handlerutil.NewValidationError("spec.ingress[].target.service", ing.Target.Service,
-						"ingress "+ing.Name+": target service "+ing.Target.Service+" does not exist in spec.services"), logger)
-				return
-			}
-
-			if ing.Target.Port <= 0 {
-				h.problemWriter.WriteError(traceCtx, w,
-					handlerutil.NewValidationError("spec.ingress[].target.port", ing.Target.Port,
-						fmt.Sprintf("ingress %s: target port must be greater than 0", ing.Name)), logger)
-				return
-			}
-
-			if ing.Access.Scope != "" && ing.Access.Scope != v1.IngressScopeInternal {
-				h.problemWriter.WriteError(traceCtx, w,
-					handlerutil.NewValidationError("spec.ingress[].access.scope", ing.Access.Scope,
-						"ingress "+ing.Name+": only \"Internal\" scope is supported"), logger)
-				return
-			}
-		}
 	}
 
 	// New projects start in Pending phase; the Scheduler will assign a node.
@@ -164,6 +158,61 @@ func (h *Handler) createProject(w http.ResponseWriter, r *http.Request) {
 
 	project.TypeMeta = v1.TypeMeta{APIVersion: v1.APIVersion, Kind: "Project"}
 	handlerutil.WriteJSONResponse(w, http.StatusCreated, &project)
+}
+
+func (h *Handler) updateProject(w http.ResponseWriter, r *http.Request) {
+	traceCtx, span := h.tracer.Start(r.Context(), "updateProject")
+	defer span.End()
+	logger := logutil.WithContext(traceCtx, h.logger)
+
+	name := r.PathValue("name")
+
+	var project v1.Project
+	if err := json.NewDecoder(r.Body).Decode(&project); err != nil {
+		h.problemWriter.WriteError(traceCtx, w,
+			handlerutil.NewValidationError("body", nil, "invalid request body: "+err.Error()), logger)
+		return
+	}
+
+	// Reject requests where the body name does not match the URL path.
+	if project.Name != "" && project.Name != name {
+		h.problemWriter.WriteError(traceCtx, w,
+			handlerutil.NewValidationError("metadata.name", project.Name,
+				fmt.Sprintf("metadata.name %q does not match URL path %q", project.Name, name)), logger)
+		return
+	}
+	project.Name = name
+
+	if err := validateProjectSpec(project.Spec); err != nil {
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+
+	// TODO: add metadata.resourceVersion / optimistic concurrency in a future PR.
+
+	if err := h.store.UpdateProjectSpec(traceCtx, &project); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			h.problemWriter.WriteError(traceCtx, w,
+				fmt.Errorf("project not found: %s: %w", name, store.ErrNotFound), logger)
+			return
+		}
+		if errors.Is(err, store.ErrConflictState) {
+			h.problemWriter.WriteError(traceCtx, w, err, logger)
+			return
+		}
+		logger.Error("UpdateProjectSpec failed", zap.String("name", name), zap.Error(err))
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+
+	// Fetch the updated resource to return the full object (including status).
+	updated, err := h.store.GetProject(traceCtx, name)
+	if err != nil {
+		logger.Error("GetProject failed after update", zap.String("name", name), zap.Error(err))
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+	handlerutil.WriteJSONResponse(w, http.StatusOK, updated)
 }
 
 // listProjects handles GET /api/v1/projects.

--- a/internal/store/interface.go
+++ b/internal/store/interface.go
@@ -28,6 +28,11 @@ var ErrNotFound = errors.New("resource not found")
 // already in use.
 var ErrAlreadyExists = errors.New("resource already exists")
 
+// ErrConflictState is returned when an operation is not allowed because the
+// resource is in a state that conflicts with the request (e.g. updating a
+// Project spec while it is Running).
+var ErrConflictState = errors.New("operation conflicts with current resource state")
+
 // Store is the top-level persistence interface.  A single concrete type
 // (e.g. sqlite.Store) implements all methods; tests may implement a subset
 // via a narrow sub-interface or a hand-rolled stub.
@@ -60,6 +65,11 @@ type NodeStore interface {
 	// DeleteNode removes a Node by name.
 	// Returns ErrNotFound if it does not exist.
 	DeleteNode(ctx context.Context, name string) error
+
+	// UpdateNodeSpec writes only the user-mutable fields of a Node (spec,
+	// labels, annotations). Status is preserved. Returns ErrNotFound if it
+	// does not exist.
+	UpdateNodeSpec(ctx context.Context, node *v1.Node) error
 
 	// UpdateNodeStatus writes only the status sub-object of the named Node.
 	// This is the preferred path for the Agent heartbeat and the
@@ -105,6 +115,13 @@ type ProjectStore interface {
 	// Project.  Used by the Controller Manager to avoid overwriting Spec
 	// changes made concurrently by the API server.
 	UpdateProjectStatus(ctx context.Context, name string, status v1.ProjectStatus) error
+
+	// UpdateProjectSpec writes only the user-mutable fields of a Project
+	// (spec, labels, annotations). Status is preserved. The update is only
+	// allowed when the project's current phase is Pending or Failed; returns
+	// ErrConflictState if the project is in any other phase, and ErrNotFound
+	// if it does not exist.
+	UpdateProjectSpec(ctx context.Context, project *v1.Project) error
 
 	// ListProjectsByNodeRef returns all Projects assigned to the given node
 	// whose phase is one of the supplied phases.  Used by

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -288,6 +288,41 @@ func (s *Store) UpdateNode(ctx context.Context, node *v1.Node) error {
 	return nil
 }
 
+// UpdateNodeSpec implements store.NodeStore.
+// Only the spec, labels, annotations, and updated_at columns are written;
+// status and phase are untouched.
+func (s *Store) UpdateNodeSpec(ctx context.Context, node *v1.Node) error {
+	now := time.Now().UTC()
+
+	spec, err := json.Marshal(node.Spec)
+	if err != nil {
+		return fmt.Errorf("postgres: marshal node spec: %w", err)
+	}
+	labels, err := json.Marshal(node.Labels)
+	if err != nil {
+		return fmt.Errorf("postgres: marshal node labels: %w", err)
+	}
+	annotations, err := json.Marshal(node.Annotations)
+	if err != nil {
+		return fmt.Errorf("postgres: marshal node annotations: %w", err)
+	}
+
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE resources
+		SET spec = $1, labels = $2, annotations = $3, updated_at = $4
+		WHERE kind = $5 AND name = $6`,
+		spec, labels, annotations, now, kindNode, node.Name,
+	)
+	if err != nil {
+		return fmt.Errorf("postgres: update node spec %q: %w", node.Name, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("%w: node %q", store.ErrNotFound, node.Name)
+	}
+	s.publish(event.TopicNodeUpdated, node.Name)
+	return nil
+}
+
 // DeleteNode implements store.NodeStore.
 func (s *Store) DeleteNode(ctx context.Context, name string) error {
 	tag, err := s.pool.Exec(ctx,
@@ -559,6 +594,49 @@ func (s *Store) UpdateProjectStatus(ctx context.Context, name string, status v1.
 		return fmt.Errorf("%w: project %q", store.ErrNotFound, name)
 	}
 	s.publish(event.TopicProjectUpdated, name)
+	return nil
+}
+
+// UpdateProjectSpec implements store.ProjectStore.
+// Only the spec, labels, annotations, and updated_at columns are written;
+// status and phase are untouched. The update is only allowed when the
+// project's current phase is Pending or Failed; returns ErrConflictState
+// otherwise.
+func (s *Store) UpdateProjectSpec(ctx context.Context, project *v1.Project) error {
+	now := time.Now().UTC()
+
+	spec, err := json.Marshal(project.Spec)
+	if err != nil {
+		return fmt.Errorf("postgres: marshal project spec: %w", err)
+	}
+	labels, err := json.Marshal(project.Labels)
+	if err != nil {
+		return fmt.Errorf("postgres: marshal project labels: %w", err)
+	}
+	annotations, err := json.Marshal(project.Annotations)
+	if err != nil {
+		return fmt.Errorf("postgres: marshal project annotations: %w", err)
+	}
+
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE resources
+		SET spec = $1, labels = $2, annotations = $3, updated_at = $4
+		WHERE kind = $5 AND name = $6 AND phase = ANY($7)`,
+		spec, labels, annotations, now, kindProject, project.Name,
+		[]string{string(v1.ProjectPhasePending), string(v1.ProjectPhaseFailed)},
+	)
+	if err != nil {
+		return fmt.Errorf("postgres: update project spec %q: %w", project.Name, err)
+	}
+	if tag.RowsAffected() == 0 {
+		// Distinguish "not found" from "wrong phase" by checking existence.
+		_, getErr := s.getProject(ctx, project.Name)
+		if getErr != nil {
+			return fmt.Errorf("%w: project %q", store.ErrNotFound, project.Name)
+		}
+		return fmt.Errorf("%w: project %q is not in Pending or Failed phase", store.ErrConflictState, project.Name)
+	}
+	s.publish(event.TopicProjectUpdated, project.Name)
 	return nil
 }
 

--- a/test/integration/node_test.go
+++ b/test/integration/node_test.go
@@ -202,6 +202,73 @@ func TestNodeCRUD(t *testing.T) {
 	drainBody(resp)
 }
 
+// TestNodeUpdate exercises PUT /api/v1/nodes/{name}:
+//
+//	PUT on existing node  → 200, spec updated, status preserved
+//	PUT on non-existent   → 404
+//	PUT with name mismatch → 400
+func TestNodeUpdate(t *testing.T) {
+	const nodeName = "e2e-node-update"
+
+	// ── Setup: create a node ──────────────────────────────────────────────────
+
+	createBody := mustMarshal(t, v1.Node{
+		ObjectMeta: v1.ObjectMeta{Name: nodeName},
+		Spec:       v1.NodeSpec{Hostname: "original-host"},
+	})
+	resp := doRequest(t, http.MethodPost, "/api/v1/nodes", createBody)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "create node: expected 201")
+	drainBody(resp)
+
+	// Send a heartbeat so the node has a non-default status.
+	heartbeatBody := mustMarshal(t, map[string]string{"state": string(v1.NodeStateReady)})
+	resp = doRequest(t, http.MethodPost, "/api/v1/nodes/"+nodeName+"/heartbeat", heartbeatBody)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode, "heartbeat: expected 204")
+	drainBody(resp)
+
+	// ── 1. PUT updates spec, preserves status ─────────────────────────────────
+
+	updateBody := mustMarshal(t, v1.Node{
+		ObjectMeta: v1.ObjectMeta{Name: nodeName},
+		Spec:       v1.NodeSpec{Hostname: "updated-host", Unschedulable: true},
+	})
+	resp = doRequest(t, http.MethodPut, "/api/v1/nodes/"+nodeName, updateBody)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "update node: expected 200")
+
+	var updated v1.Node
+	mustDecodeBody(t, resp, &updated)
+	assert.Equal(t, nodeName, updated.Name)
+	assert.Equal(t, "updated-host", updated.Spec.Hostname, "spec.hostname should be updated")
+	assert.True(t, updated.Spec.Unschedulable, "spec.unschedulable should be true")
+	assert.Equal(t, v1.NodeStateReady, updated.Status.State, "status.state must be preserved")
+
+	// ── 2. PUT on non-existent node → 404 ─────────────────────────────────────
+
+	nonExistentBody := mustMarshal(t, v1.Node{
+		ObjectMeta: v1.ObjectMeta{Name: "no-such-node"},
+		Spec:       v1.NodeSpec{Hostname: "ghost"},
+	})
+	resp = doRequest(t, http.MethodPut, "/api/v1/nodes/no-such-node", nonExistentBody)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode, "update non-existent: expected 404")
+	drainBody(resp)
+
+	// ── 3. PUT with name mismatch → 400 ───────────────────────────────────────
+
+	mismatchBody := mustMarshal(t, v1.Node{
+		ObjectMeta: v1.ObjectMeta{Name: "different-name"},
+		Spec:       v1.NodeSpec{Hostname: "mismatch"},
+	})
+	resp = doRequest(t, http.MethodPut, "/api/v1/nodes/"+nodeName, mismatchBody)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "name mismatch: expected 400")
+	drainBody(resp)
+
+	// ── Cleanup ───────────────────────────────────────────────────────────────
+
+	resp = doRequest(t, http.MethodDelete, "/api/v1/nodes/"+nodeName, nil)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode, "cleanup delete")
+	drainBody(resp)
+}
+
 // TestNodeHeartbeatStateValidation verifies that the heartbeat endpoint
 // rejects unrecognised state values with 400 and accepts valid ones with 204.
 func TestNodeHeartbeatStateValidation(t *testing.T) {

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -202,3 +202,100 @@ func TestProjectNameValidation(t *testing.T) {
 		drainBody(resp)
 	}
 }
+
+// TestProjectUpdate exercises PUT /api/v1/projects/{name}:
+//
+//	PUT on Pending project  → 200, spec updated
+//	PUT on non-existent     → 404
+//	PUT with name mismatch  → 400
+//	PUT on Running project  → 409 (conflict state)
+func TestProjectUpdate(t *testing.T) {
+	const projectName = "e2e-project-update"
+
+	validSpec := v1.ProjectSpec{
+		Services: []v1.ServiceDef{
+			{Name: "web", Image: "nginx:latest"},
+		},
+	}
+
+	// ── Setup: create a project (starts in Pending) ───────────────────────────
+
+	createBody := mustMarshal(t, v1.Project{
+		ObjectMeta: v1.ObjectMeta{Name: projectName},
+		Spec:       validSpec,
+	})
+	resp := doRequest(t, http.MethodPost, "/api/v1/projects", createBody)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "create project: expected 201")
+	drainBody(resp)
+
+	// ── 1. PUT updates spec in Pending phase → 200 ────────────────────────────
+
+	updatedSpec := v1.ProjectSpec{
+		Services: []v1.ServiceDef{
+			{Name: "api", Image: "myapp:v2"},
+		},
+	}
+	updateBody := mustMarshal(t, v1.Project{
+		ObjectMeta: v1.ObjectMeta{Name: projectName},
+		Spec:       updatedSpec,
+	})
+	resp = doRequest(t, http.MethodPut, "/api/v1/projects/"+projectName, updateBody)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "update project: expected 200")
+
+	var updated v1.Project
+	mustDecodeBody(t, resp, &updated)
+	assert.Equal(t, projectName, updated.Name)
+	require.Len(t, updated.Spec.Services, 1)
+	assert.Equal(t, "api", updated.Spec.Services[0].Name, "service name should be updated")
+	assert.Equal(t, "myapp:v2", updated.Spec.Services[0].Image, "service image should be updated")
+	assert.Equal(t, v1.ProjectPhasePending, updated.Status.Phase, "phase should still be Pending")
+
+	// ── 2. PUT on non-existent project → 404 ──────────────────────────────────
+
+	nonExistentBody := mustMarshal(t, v1.Project{
+		ObjectMeta: v1.ObjectMeta{Name: "no-such-project"},
+		Spec:       validSpec,
+	})
+	resp = doRequest(t, http.MethodPut, "/api/v1/projects/no-such-project", nonExistentBody)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode, "update non-existent: expected 404")
+	drainBody(resp)
+
+	// ── 3. PUT with name mismatch → 400 ───────────────────────────────────────
+
+	mismatchBody := mustMarshal(t, v1.Project{
+		ObjectMeta: v1.ObjectMeta{Name: "different-name"},
+		Spec:       validSpec,
+	})
+	resp = doRequest(t, http.MethodPut, "/api/v1/projects/"+projectName, mismatchBody)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "name mismatch: expected 400")
+	drainBody(resp)
+
+	// ── 4. Transition to Running, then PUT → 409 ──────────────────────────────
+
+	// Patch phase to Running via status endpoint.
+	patchBody := mustMarshal(t, map[string]string{"phase": string(v1.ProjectPhaseRunning)})
+	resp = doRequest(t, http.MethodPatch, "/api/v1/projects/"+projectName+"/status", patchBody)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode, "patch to Running: expected 204")
+	drainBody(resp)
+
+	resp = doRequest(t, http.MethodPut, "/api/v1/projects/"+projectName, updateBody)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode, "update Running project: expected 409")
+	drainBody(resp)
+
+	// ── 5. Transition to Failed, then PUT → 200 (allowed) ────────────────────
+
+	patchBody = mustMarshal(t, map[string]string{"phase": string(v1.ProjectPhaseFailed)})
+	resp = doRequest(t, http.MethodPatch, "/api/v1/projects/"+projectName+"/status", patchBody)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode, "patch to Failed: expected 204")
+	drainBody(resp)
+
+	resp = doRequest(t, http.MethodPut, "/api/v1/projects/"+projectName, updateBody)
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "update Failed project: expected 200")
+	drainBody(resp)
+
+	// ── Cleanup ───────────────────────────────────────────────────────────────
+
+	resp = doRequest(t, http.MethodDelete, "/api/v1/projects/"+projectName, nil)
+	assert.Contains(t, []int{http.StatusNoContent, http.StatusAccepted}, resp.StatusCode, "delete project")
+	drainBody(resp)
+}


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add `PUT /api/v1/nodes/{name}` and `PUT /api/v1/projects/{name}` endpoints for updating resource specs
- Implement create-or-update logic in `caractl apply` (POST first, fallback to PUT on 409)
- Resolve issue CARA-20

Previously, `caractl apply -f` always sent a POST request, meaning re-applying an existing resource failed with 409 Conflict. Users had to manually delete and recreate resources for any iterative workflow. This PR adds full update support across the stack.

## Additional Information

### Store layer
- New `ErrConflictState` sentinel error for phase-guarded operations
- New `UpdateNodeSpec` / `UpdateProjectSpec` methods that only UPDATE user-mutable columns (spec, labels, annotations) — status and phase are untouched
- `UpdateProjectSpec` enforces a phase guard at the SQL level: only projects in Pending or Failed phase can be updated. Projects in Scheduled/Running/Terminating return `ErrConflictState`
- Both methods publish events (`TopicNodeUpdated` / `TopicProjectUpdated`) so controllers can react to spec changes

### Server handlers
- Node PUT handler: validates name match between URL path and body, calls `UpdateNodeSpec`, returns full object with 200
- Project PUT handler: validates name match and spec (reused `validateProjectSpec` helper extracted from create), calls `UpdateProjectSpec`
- `ErrConflictState` mapped to 409 Conflict in the problem mapping

### CLI
- `applyNode` / `applyProject`: POST-then-PUT-on-409 pattern (avoids race conditions, costs one extra request only for updates)
- `printApplyConfirmation` now distinguishes "created" vs "configured"
- New `ApplyResult` struct wraps the resource + a `Created` flag

### Design decisions
- **New store methods vs GET-then-merge**: Chose new `UpdateNodeSpec`/`UpdateProjectSpec` methods that issue targeted SQL UPDATEs on spec/labels/annotations columns only, rather than reading the full object and merging. This is more surgical and avoids read-modify-write race conditions.
- **Phase guard in store layer**: The `UpdateProjectSpec` SQL includes `WHERE phase = ANY('Pending','Failed')` so the guard is atomic. On 0 rows affected, a follow-up GET distinguishes "not found" from "wrong phase".
- **Optimistic concurrency**: Deferred to a future PR (TODO comments added). For MVP, no `resourceVersion` checking.