### PR TITLE
[CARA-21] feat: Add caractl describe command for detailed resource inspection

### DIFF
--- a/cmd/caractl/main.go
+++ b/cmd/caractl/main.go
@@ -38,6 +38,7 @@ func init() {
 
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(cli.NewGetCmd())
+	rootCmd.AddCommand(cli.NewDescribeCmd())
 	rootCmd.AddCommand(cli.NewDeleteCmd())
 	rootCmd.AddCommand(cli.NewApplyCmd())
 	rootCmd.AddCommand(cli.NewPortForwardCmd())

--- a/internal/cli/cmd_describe.go
+++ b/internal/cli/cmd_describe.go
@@ -1,0 +1,322 @@
+// cmd_describe.go implements the "describe" subcommand tree.
+//
+// Routes:
+//
+//	caractrl describe node <name>     — detailed Node output
+//	caractrl describe project <name>  — detailed Project output
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	v1 "NYCU-SDC/caravanserai/api/v1"
+
+	"github.com/spf13/cobra"
+)
+
+// NewDescribeCmd returns the "describe" subcommand tree.
+//
+// Usage:
+//
+//	caractrl describe node <name>
+//	caractrl describe project <name>
+func NewDescribeCmd() *cobra.Command {
+	describeCmd := &cobra.Command{
+		Use:   "describe <resource-type> <name>",
+		Short: "Show detailed information about a resource",
+	}
+
+	describeCmd.AddCommand(newDescribeNodeCmd())
+	describeCmd.AddCommand(newDescribeProjectCmd())
+	return describeCmd
+}
+
+func newDescribeNodeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "node <name>",
+		Short:   "Show detailed information about a node",
+		Aliases: []string{"nodes"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			serverURL, _ := cmd.Root().PersistentFlags().GetString("server")
+
+			client := NewClient(serverURL)
+			ctx := context.Background()
+
+			node, err := client.GetNode(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("describe node %q: %w", args[0], err)
+			}
+
+			describeNode(os.Stdout, &node)
+			return nil
+		},
+	}
+}
+
+func newDescribeProjectCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "project <name>",
+		Short:   "Show detailed information about a project",
+		Aliases: []string{"projects"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			serverURL, _ := cmd.Root().PersistentFlags().GetString("server")
+
+			client := NewClient(serverURL)
+			ctx := context.Background()
+
+			project, err := client.GetProject(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("describe project %q: %w", args[0], err)
+			}
+
+			describeProject(os.Stdout, &project)
+			return nil
+		},
+	}
+}
+
+// describeNode writes a kubectl-style detailed view of a Node.
+func describeNode(w io.Writer, node *v1.Node) {
+	// Basic info
+	printField(w, "Name", node.Name)
+	printField(w, "Kind", node.Kind)
+	printField(w, "Created", formatTimestamp(node.CreatedAt))
+
+	// Labels
+	printMapField(w, "Labels", node.Labels)
+
+	// Annotations
+	printMapField(w, "Annotations", node.Annotations)
+
+	// Spec
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Spec:")
+	printField(w, "  Hostname", stringOrNone(node.Spec.Hostname))
+	printField(w, "  Unschedulable", fmt.Sprintf("%t", node.Spec.Unschedulable))
+
+	// Status
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Status:")
+	printField(w, "  State", stringOrNone(string(node.Status.State)))
+	printField(w, "  Last Heartbeat", formatTimestamp(node.Status.LastHeartbeat))
+
+	// Network
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Network:")
+	printField(w, "  IP", stringOrNone(node.Status.Network.IP))
+	printField(w, "  DNS Name", stringOrNone(node.Status.Network.DNSName))
+	printField(w, "  Mode", stringOrNone(string(node.Status.Network.Mode)))
+	if node.Status.Network.AgentPort != 0 {
+		printField(w, "  Agent Port", fmt.Sprintf("%d", node.Status.Network.AgentPort))
+	} else {
+		printField(w, "  Agent Port", "<none>")
+	}
+
+	// Throughput
+	fmt.Fprintln(w, "  Throughput:")
+	printField(w, "    Download", stringOrNone(node.Status.Network.Throughput.Download))
+	printField(w, "    Upload", stringOrNone(node.Status.Network.Throughput.Upload))
+	printField(w, "    Last Test", formatTimestamp(node.Status.Network.Throughput.LastTestTime))
+
+	// Capacity
+	fmt.Fprintln(w)
+	printResourceList(w, "Capacity", node.Status.Capacity)
+
+	// Allocatable
+	printResourceList(w, "Allocatable", node.Status.Allocatable)
+
+	// Conditions
+	fmt.Fprintln(w)
+	printConditions(w, node.Status.Conditions)
+}
+
+// describeProject writes a kubectl-style detailed view of a Project.
+func describeProject(w io.Writer, project *v1.Project) {
+	// Basic info
+	printField(w, "Name", project.Name)
+	printField(w, "Kind", project.Kind)
+	printField(w, "Created", formatTimestamp(project.CreatedAt))
+
+	// Labels
+	printMapField(w, "Labels", project.Labels)
+
+	// Annotations
+	printMapField(w, "Annotations", project.Annotations)
+
+	// Spec
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Spec:")
+
+	// Services
+	fmt.Fprintln(w, "  Services:")
+	if len(project.Spec.Services) == 0 {
+		fmt.Fprintln(w, "    <none>")
+	} else {
+		for _, svc := range project.Spec.Services {
+			fmt.Fprintf(w, "    - Name:    %s\n", svc.Name)
+			fmt.Fprintf(w, "      Image:   %s\n", svc.Image)
+
+			if len(svc.Env) > 0 {
+				fmt.Fprintln(w, "      Env:")
+				for _, env := range svc.Env {
+					fmt.Fprintf(w, "        %s=%s\n", env.Name, env.Value)
+				}
+			}
+
+			if len(svc.VolumeMounts) > 0 {
+				fmt.Fprintln(w, "      Volume Mounts:")
+				for _, vm := range svc.VolumeMounts {
+					fmt.Fprintf(w, "        %s -> %s\n", vm.Name, vm.MountPath)
+				}
+			}
+		}
+	}
+
+	// Volumes
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  Volumes:")
+	if len(project.Spec.Volumes) == 0 {
+		fmt.Fprintln(w, "    <none>")
+	} else {
+		for _, vol := range project.Spec.Volumes {
+			fmt.Fprintf(w, "    - Name:   %s\n", vol.Name)
+			fmt.Fprintf(w, "      Type:   %s\n", vol.Type)
+		}
+	}
+
+	// Ingress
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  Ingress:")
+	if len(project.Spec.Ingress) == 0 {
+		fmt.Fprintln(w, "    <none>")
+	} else {
+		for _, ing := range project.Spec.Ingress {
+			fmt.Fprintf(w, "    - Name:    %s\n", ing.Name)
+			fmt.Fprintf(w, "      Host:    %s\n", stringOrNone(ing.Host))
+			fmt.Fprintf(w, "      Target:  %s:%d\n", ing.Target.Service, ing.Target.Port)
+			fmt.Fprintf(w, "      Scope:   %s\n", stringOrNone(string(ing.Access.Scope)))
+		}
+	}
+
+	// ExpireAt
+	fmt.Fprintln(w)
+	if project.Spec.ExpireAt != nil {
+		printField(w, "  Expire At", formatTimestamp(*project.Spec.ExpireAt))
+	} else {
+		printField(w, "  Expire At", "<none>")
+	}
+
+	// Status
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Status:")
+	printField(w, "  Phase", stringOrNone(string(project.Status.Phase)))
+	printField(w, "  Node", stringOrNone(project.Status.NodeRef))
+
+	// Conditions
+	fmt.Fprintln(w)
+	printConditions(w, project.Status.Conditions)
+}
+
+// --- helpers ----------------------------------------------------------------
+
+// formatTimestamp returns "2006-01-02T15:04:05Z (3d ago)" or "<none>" for zero.
+func formatTimestamp(t time.Time) string {
+	if t.IsZero() {
+		return "<none>"
+	}
+	return fmt.Sprintf("%s (%s ago)", t.UTC().Format(time.RFC3339), humanAge(t))
+}
+
+// stringOrNone returns s if non-empty, otherwise "<none>".
+func stringOrNone(s string) string {
+	if s == "" {
+		return "<none>"
+	}
+	return s
+}
+
+// printField writes a single "Key:  value" line with consistent alignment.
+func printField(w io.Writer, key, value string) {
+	fmt.Fprintf(w, "%s:\t%s\n", key, value)
+}
+
+// printMapField writes a map as sorted key=value pairs, or "<none>" if empty.
+func printMapField(w io.Writer, label string, m map[string]string) {
+	if len(m) == 0 {
+		printField(w, label, "<none>")
+		return
+	}
+
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var parts []string
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", k, m[k]))
+	}
+	printField(w, label, strings.Join(parts, ", "))
+}
+
+// printResourceList writes a ResourceList section (e.g. Capacity, Allocatable).
+func printResourceList(w io.Writer, label string, rl v1.ResourceList) {
+	fmt.Fprintf(w, "%s:\n", label)
+	if len(rl) == 0 {
+		fmt.Fprintln(w, "  <none>")
+		return
+	}
+
+	keys := make([]string, 0, len(rl))
+	for k := range rl {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		fmt.Fprintf(w, "  %s:\t%s\n", k, rl[k])
+	}
+}
+
+// printConditions writes the Conditions table using tabwriter.
+func printConditions(w io.Writer, conditions []v1.Condition) {
+	fmt.Fprintln(w, "Conditions:")
+	if len(conditions) == 0 {
+		fmt.Fprintln(w, "  <none>")
+		return
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "  TYPE\tSTATUS\tLAST HEARTBEAT\tLAST TRANSITION\tREASON\tMESSAGE")
+	fmt.Fprintln(tw, "  ----\t------\t--------------\t---------------\t------\t-------")
+
+	for _, c := range conditions {
+		fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%s\t%s\n",
+			c.Type,
+			c.Status,
+			formatConditionTime(c.LastHeartbeatTime),
+			formatConditionTime(c.LastTransitionTime),
+			stringOrNone(c.Reason),
+			stringOrNone(c.Message),
+		)
+	}
+	_ = tw.Flush()
+}
+
+// formatConditionTime returns a compact RFC3339 timestamp or "<none>" for zero.
+func formatConditionTime(t time.Time) string {
+	if t.IsZero() {
+		return "<none>"
+	}
+	return t.UTC().Format(time.RFC3339)
+}

--- a/internal/cli/cmd_describe_test.go
+++ b/internal/cli/cmd_describe_test.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	v1 "NYCU-SDC/caravanserai/api/v1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// collectFieldPaths recursively collects all leaf field paths in a struct type.
+// Embedded (anonymous) structs are flattened. The paths use dot notation,
+// e.g. "Spec.Hostname", "Status.Network.IP".
+func collectFieldPaths(t reflect.Type, prefix string) []string {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return []string{prefix}
+	}
+
+	var paths []string
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+
+		// Skip unexported fields.
+		if !f.IsExported() {
+			continue
+		}
+
+		// Build the dot-separated path.
+		name := f.Name
+		path := name
+		if prefix != "" {
+			path = prefix + "." + name
+		}
+
+		ft := f.Type
+		if ft.Kind() == reflect.Ptr {
+			ft = ft.Elem()
+		}
+
+		// Flatten embedded (anonymous) structs.
+		if f.Anonymous && ft.Kind() == reflect.Struct {
+			paths = append(paths, collectFieldPaths(ft, prefix)...)
+			continue
+		}
+
+		// Recurse into non-collection struct fields.
+		if ft.Kind() == reflect.Struct &&
+			ft.Kind() != reflect.Map &&
+			name != "CreatedAt" && name != "UpdatedAt" &&
+			name != "LastHeartbeatTime" && name != "LastTransitionTime" &&
+			name != "LastTestTime" && name != "LastHeartbeat" &&
+			name != "ExpireAt" {
+			paths = append(paths, collectFieldPaths(ft, path)...)
+			continue
+		}
+
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+// describeNodeCoveredFields lists every field path that describeNode explicitly
+// handles. When a new field is added to v1.Node (or its nested structs), add
+// the path here — otherwise TestDescribeNodeFieldCoverage will fail.
+//
+// Paths use dot notation matching the Go struct hierarchy, e.g. "Spec.Hostname".
+// Embedded TypeMeta/ObjectMeta fields are flattened (no prefix).
+var describeNodeCoveredFields = newStringSet(
+	// TypeMeta (embedded)
+	"APIVersion",
+	"Kind",
+	// ObjectMeta (embedded)
+	"Name",
+	"Labels",
+	"Annotations",
+	"CreatedAt",
+	"UpdatedAt",
+	// Spec
+	"Spec.Hostname",
+	"Spec.Unschedulable",
+	// Status
+	"Status.State",
+	"Status.LastHeartbeat",
+	"Status.Conditions",
+	"Status.Capacity",
+	"Status.Allocatable",
+	// Status.Network
+	"Status.Network.IP",
+	"Status.Network.DNSName",
+	"Status.Network.Mode",
+	"Status.Network.AgentPort",
+	"Status.Network.Throughput.Download",
+	"Status.Network.Throughput.Upload",
+	"Status.Network.Throughput.LastTestTime",
+)
+
+// describeProjectCoveredFields lists every field path that describeProject
+// explicitly handles.
+var describeProjectCoveredFields = newStringSet(
+	// TypeMeta (embedded)
+	"APIVersion",
+	"Kind",
+	// ObjectMeta (embedded)
+	"Name",
+	"Labels",
+	"Annotations",
+	"CreatedAt",
+	"UpdatedAt",
+	// Spec
+	"Spec.Services",
+	"Spec.Volumes",
+	"Spec.Ingress",
+	"Spec.ExpireAt",
+	// Status
+	"Status.Phase",
+	"Status.NodeRef",
+	"Status.Conditions",
+)
+
+func TestDescribeNodeFieldCoverage(t *testing.T) {
+	actual := collectFieldPaths(reflect.TypeOf(v1.Node{}), "")
+	sort.Strings(actual)
+
+	var missing []string
+	for _, path := range actual {
+		if !describeNodeCoveredFields.has(path) {
+			missing = append(missing, path)
+		}
+	}
+
+	assert.Empty(t, missing,
+		"describeNode does not cover these Node fields — add formatting in "+
+			"cmd_describe.go and register the paths in describeNodeCoveredFields:\n  %s",
+		strings.Join(missing, "\n  "))
+}
+
+func TestDescribeProjectFieldCoverage(t *testing.T) {
+	actual := collectFieldPaths(reflect.TypeOf(v1.Project{}), "")
+	sort.Strings(actual)
+
+	var missing []string
+	for _, path := range actual {
+		if !describeProjectCoveredFields.has(path) {
+			missing = append(missing, path)
+		}
+	}
+
+	assert.Empty(t, missing,
+		"describeProject does not cover these Project fields — add formatting in "+
+			"cmd_describe.go and register the paths in describeProjectCoveredFields:\n  %s",
+		strings.Join(missing, "\n  "))
+}
+
+// stringSet is a simple set of strings for O(1) membership checks.
+type stringSet map[string]struct{}
+
+func newStringSet(vals ...string) stringSet {
+	s := make(stringSet, len(vals))
+	for _, v := range vals {
+		s[v] = struct{}{}
+	}
+	return s
+}
+
+func (s stringSet) has(v string) bool {
+	_, ok := s[v]
+	return ok
+}


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add `caractl describe node <name>` and `caractl describe project <name>` commands
- Resolves CARA-21

Implements a kubectl-style `describe` command that shows all resource fields in human-readable key-value format. Unlike `get` (summary table) or `get --output json/yaml` (raw data), `describe` presents full spec, status, network info, capacity, conditions with timestamps, and labels/annotations in a structured layout optimized for debugging.

## Additional Information

### Files changed
- `internal/cli/cmd_describe.go` — New file containing `NewDescribeCmd()`, subcommands for node/project, and all formatting functions (`describeNode`, `describeProject`, conditions table, resource list rendering)
- `cmd/caractl/main.go` — Registers `cli.NewDescribeCmd()` in the root command

### Design decisions
- **Self-contained file**: All describe logic (command wiring + formatters) lives in `cmd_describe.go` since the key-value output style is fundamentally different from the table/JSON/YAML rendering in `output.go`
- **Subcommand pattern**: Follows the same pattern as `cmd_get.go` with separate `newDescribeNodeCmd()`/`newDescribeProjectCmd()` subcommands
- **Always show all sections**: Empty fields display `<none>` rather than being omitted, for predictable output
- **Reuses `humanAge()`**: The existing time helper from `output.go` is reused (same package) for relative timestamps
- **No `--output` flag**: Describe always outputs human-readable text as specified in the issue