### PR TITLE
[CARA-31] feat: Add force-delete option to Project DELETE API

### DIFF
--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -236,9 +236,15 @@ func (c *Client) GetProject(ctx context.Context, name string) (v1.Project, error
 // DeleteProject removes a project by name.
 // It returns (true, nil) when the project was deleted immediately (204 No Content)
 // and (false, nil) when the project has been marked for graceful termination
-// (202 Accepted).
-func (c *Client) DeleteProject(ctx context.Context, name string) (deleted bool, err error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.BaseURL+"/api/v1/projects/"+name, nil)
+// (202 Accepted). When force is true, the server bypasses the two-phase
+// lifecycle and hard-deletes the project regardless of current phase.
+func (c *Client) DeleteProject(ctx context.Context, name string, force bool) (deleted bool, err error) {
+	url := c.BaseURL + "/api/v1/projects/" + name
+	if force {
+		url += "?force=true"
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return false, fmt.Errorf("build request: %w", err)
 	}

--- a/internal/cli/cmd_delete.go
+++ b/internal/cli/cmd_delete.go
@@ -48,19 +48,20 @@ func newDeleteNodeCmd() *cobra.Command {
 }
 
 func newDeleteProjectCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "project <name>",
 		Short:   "Delete a project",
 		Aliases: []string{"projects"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			serverURL, _ := cmd.Root().PersistentFlags().GetString("server")
+			force, _ := cmd.Flags().GetBool("force")
 			name := args[0]
 
 			client := NewClient(serverURL)
 			ctx := context.Background()
 
-			deleted, err := client.DeleteProject(ctx, name)
+			deleted, err := client.DeleteProject(ctx, name, force)
 			if err != nil {
 				return fmt.Errorf("delete project %q: %w", name, err)
 			}
@@ -73,4 +74,8 @@ func newDeleteProjectCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().Bool("force", false, "Immediately hard-delete the project, bypassing graceful termination. Docker resources on the node may be orphaned.")
+
+	return cmd
 }

--- a/internal/server/handler/project/handler.go
+++ b/internal/server/handler/project/handler.go
@@ -6,7 +6,7 @@
 //	PUT    /api/v1/projects/{name}           — update a Project's spec
 //	GET    /api/v1/projects                  — list Projects (supports ?phase= and ?nodeRef= filters)
 //	GET    /api/v1/projects/{name}           — get a single Project
-//	DELETE /api/v1/projects/{name}           — delete a Project
+//	DELETE /api/v1/projects/{name}           — delete a Project (supports ?force=true for immediate hard-delete)
 //	PATCH  /api/v1/projects/{name}/status    — Agent reports observed phase (Running / Failed / Terminated)
 package project
 
@@ -314,12 +314,19 @@ func (h *Handler) getProject(w http.ResponseWriter, r *http.Request) {
 //     phase and performs the final store deletion.
 //
 // Calling DELETE on an already-Terminating project is idempotent (202).
+//
+// When the ?force=true query parameter is set, the handler bypasses the
+// two-phase lifecycle and directly hard-deletes the project from the store
+// regardless of current phase, returning 204 No Content.  A warning is logged
+// when the project has a nodeRef set, indicating Docker resources on the node
+// may be orphaned.
 func (h *Handler) deleteProject(w http.ResponseWriter, r *http.Request) {
 	traceCtx, span := h.tracer.Start(r.Context(), "deleteProject")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, h.logger)
 
 	name := r.PathValue("name")
+	force := r.URL.Query().Get("force") == "true"
 
 	project, err := h.store.GetProject(traceCtx, name)
 	if err != nil {
@@ -330,6 +337,30 @@ func (h *Handler) deleteProject(w http.ResponseWriter, r *http.Request) {
 		}
 		logger.Error("GetProject failed during delete", zap.String("name", name), zap.Error(err))
 		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+
+	// Force-delete: bypass the two-phase lifecycle and hard-delete immediately.
+	if force {
+		if project.Status.NodeRef != "" {
+			logger.Warn("Force-deleting project with nodeRef set; Docker resources on the node may be orphaned",
+				zap.String("project", name),
+				zap.String("phase", string(project.Status.Phase)),
+				zap.String("nodeRef", project.Status.NodeRef))
+		}
+		if err := h.store.DeleteProject(traceCtx, name); err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				h.problemWriter.WriteError(traceCtx, w,
+					fmt.Errorf("project not found: %s: %w", name, store.ErrNotFound), logger)
+				return
+			}
+			logger.Error("Force DeleteProject failed", zap.String("name", name), zap.Error(err))
+			h.problemWriter.WriteError(traceCtx, w, err, logger)
+			return
+		}
+		logger.Info("Project force-deleted", zap.String("project", name),
+			zap.String("phase", string(project.Status.Phase)))
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -299,3 +299,95 @@ func TestProjectUpdate(t *testing.T) {
 	assert.Contains(t, []int{http.StatusNoContent, http.StatusAccepted}, resp.StatusCode, "delete project")
 	drainBody(resp)
 }
+
+// TestProjectForceDelete verifies the ?force=true query parameter on
+// DELETE /api/v1/projects/{name}:
+//
+//	Force-delete a Running project       → 204, project gone
+//	Force-delete a Terminating project    → 204, project gone
+//	Force-delete a Pending project        → 204 (same as normal delete)
+//	Normal delete on Running project      → 202 (existing behaviour preserved)
+func TestProjectForceDelete(t *testing.T) {
+	// createProject is a helper that creates a project in Pending phase.
+	createProject := func(t *testing.T, name string) {
+		t.Helper()
+		body := mustMarshal(t, v1.Project{
+			ObjectMeta: v1.ObjectMeta{Name: name},
+			Spec: v1.ProjectSpec{
+				Services: []v1.ServiceDef{
+					{Name: "web", Image: "nginx:latest"},
+				},
+			},
+		})
+		resp := doRequest(t, http.MethodPost, "/api/v1/projects", body)
+		require.Equal(t, http.StatusCreated, resp.StatusCode, "create project %q", name)
+		drainBody(resp)
+	}
+
+	// patchPhase transitions a project to the given phase via the status endpoint.
+	patchPhase := func(t *testing.T, name string, phase v1.ProjectPhase) {
+		t.Helper()
+		body := mustMarshal(t, map[string]string{"phase": string(phase)})
+		resp := doRequest(t, http.MethodPatch, "/api/v1/projects/"+name+"/status", body)
+		require.Equal(t, http.StatusNoContent, resp.StatusCode, "patch %q to %s", name, phase)
+		drainBody(resp)
+	}
+
+	// assertGone verifies a project no longer exists in the store.
+	assertGone := func(t *testing.T, name string) {
+		t.Helper()
+		resp := doRequest(t, http.MethodGet, "/api/v1/projects/"+name, nil)
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode, "project %q should be gone", name)
+		drainBody(resp)
+	}
+
+	t.Run("Force-delete Running project returns 204 and removes from store", func(t *testing.T) {
+		const name = "e2e-force-del-running"
+		createProject(t, name)
+		patchPhase(t, name, v1.ProjectPhaseRunning)
+
+		resp := doRequest(t, http.MethodDelete, "/api/v1/projects/"+name+"?force=true", nil)
+		require.Equal(t, http.StatusNoContent, resp.StatusCode)
+		drainBody(resp)
+
+		assertGone(t, name)
+	})
+
+	t.Run("Force-delete Terminating project returns 204 and removes from store", func(t *testing.T) {
+		const name = "e2e-force-del-terminating"
+		createProject(t, name)
+		patchPhase(t, name, v1.ProjectPhaseTerminating)
+
+		resp := doRequest(t, http.MethodDelete, "/api/v1/projects/"+name+"?force=true", nil)
+		require.Equal(t, http.StatusNoContent, resp.StatusCode)
+		drainBody(resp)
+
+		assertGone(t, name)
+	})
+
+	t.Run("Force-delete Pending project returns 204", func(t *testing.T) {
+		const name = "e2e-force-del-pending"
+		createProject(t, name)
+
+		resp := doRequest(t, http.MethodDelete, "/api/v1/projects/"+name+"?force=true", nil)
+		require.Equal(t, http.StatusNoContent, resp.StatusCode)
+		drainBody(resp)
+
+		assertGone(t, name)
+	})
+
+	t.Run("Normal delete on Running project returns 202 (existing behaviour)", func(t *testing.T) {
+		const name = "e2e-normal-del-running"
+		createProject(t, name)
+		patchPhase(t, name, v1.ProjectPhaseRunning)
+
+		resp := doRequest(t, http.MethodDelete, "/api/v1/projects/"+name, nil)
+		require.Equal(t, http.StatusAccepted, resp.StatusCode)
+		drainBody(resp)
+
+		// Cleanup: force-delete so the project doesn't linger.
+		resp = doRequest(t, http.MethodDelete, "/api/v1/projects/"+name+"?force=true", nil)
+		assert.Contains(t, []int{http.StatusNoContent, http.StatusAccepted}, resp.StatusCode, "cleanup")
+		drainBody(resp)
+	})
+}


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add `?force=true` query parameter to `DELETE /api/v1/projects/{name}` for immediate hard-deletion
- Add `--force` flag to `caractl delete project <name>` CLI command
- Resolve issue CARA-31

When a node goes offline permanently, projects stuck in active phases cannot be removed without waiting for the rescheduler's 10-minute timeout. This PR adds a force-delete option that bypasses the two-phase Terminating→Terminated lifecycle and directly hard-deletes the project from the store, analogous to `kubectl delete pod --grace-period=0 --force`.

## Additional Information

### Files changed
- `internal/server/handler/project/handler.go` — Added force-delete early-return block in `deleteProject()`. When `?force=true`, the handler fetches the project, logs a warning if `nodeRef` is set (orphaned Docker resources), then calls `store.DeleteProject()` directly and returns 204.
- `internal/cli/client.go` — Added `force bool` parameter to `DeleteProject()`, which appends `?force=true` to the URL when set.
- `internal/cli/cmd_delete.go` — Added `--force` flag to the `delete project` subcommand.
- `test/integration/project_test.go` — Added `TestProjectForceDelete` with 4 sub-tests: force-delete Running (204), force-delete Terminating (204), force-delete Pending (204), and normal delete Running (202, existing behaviour preserved).

### Design decisions
- Force-delete is phase-agnostic — works uniformly on all phases including Terminated.
- The existing non-force switch block is untouched; force logic is a clean early-return before it.
- No new store methods needed — `store.DeleteProject()` already performs a hard DELETE.