### PR TITLE
[CARA-32] fix: Improve CLI error formatting by parsing RFC 9457 Problem Details

### DIFF
--- a/cmd/caractl/main.go
+++ b/cmd/caractl/main.go
@@ -36,6 +36,9 @@ func init() {
 	rootCmd.PersistentFlags().String("server", "http://localhost:8080", "cara-server address")
 	rootCmd.PersistentFlags().String("output", "table", "output format: table | json | yaml")
 
+	// Prevent cobra from printing errors itself — main() handles it.
+	rootCmd.SilenceErrors = true
+
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(cli.NewGetCmd())
 	rootCmd.AddCommand(cli.NewDescribeCmd())
@@ -47,7 +50,7 @@ func init() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		os.Exit(1)
 	}
 }

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	v1 "NYCU-SDC/caravanserai/api/v1"
 )
@@ -325,11 +326,79 @@ func (c *Client) applyProject(ctx context.Context, raw []byte) (ApplyResult, err
 	return ApplyResult{Resource: project, Created: true}, nil
 }
 
+// APIError represents a parsed RFC 9457 Problem Details response from the
+// server. It implements the error interface so callers can use errors.As to
+// inspect server errors programmatically.
+type APIError struct {
+	StatusCode int
+	Status     string   // e.g. "409 Conflict"
+	Title      string   // e.g. "Conflict"
+	Detail     string   // e.g. "cannot delete node ...: 1 project(s) still assigned"
+	Errors     []string // validation sub-errors, if any
+}
+
+// Error returns a clean, human-readable error message.
+//
+//   - With detail:           Conflict: cannot delete node "test-node": 1 project(s) still assigned
+//   - With validation errors: Validation Error: name is required; endpoint must be a valid URL
+//   - Fallback (unparseable): server returned 409 Conflict: <raw body>
+func (e *APIError) Error() string {
+	if e.Title != "" && e.Detail != "" {
+		return fmt.Sprintf("%s: %s", e.Title, e.Detail)
+	}
+	if e.Title != "" && len(e.Errors) > 0 {
+		return fmt.Sprintf("%s: %s", e.Title, strings.Join(e.Errors, "; "))
+	}
+	if e.Detail != "" {
+		return e.Detail
+	}
+	if len(e.Errors) > 0 {
+		return strings.Join(e.Errors, "; ")
+	}
+	// Title-only (no detail or errors).
+	if e.Title != "" {
+		return e.Title
+	}
+	return fmt.Sprintf("server returned %s", e.Status)
+}
+
+// problemJSON is the wire format for RFC 9457 Problem Details.
+type problemJSON struct {
+	Title  string   `json:"title"`
+	Status int      `json:"status"`
+	Detail string   `json:"detail"`
+	Errors []string `json:"errors"`
+}
+
+// ParseAPIError attempts to parse an RFC 9457 Problem Details JSON body and
+// returns an APIError. If the body is not valid Problem JSON, the raw body is
+// stored in Detail as a fallback.
+func ParseAPIError(body []byte, httpStatus string, statusCode int) *APIError {
+	var p problemJSON
+	if err := json.Unmarshal(body, &p); err == nil && p.Title != "" {
+		return &APIError{
+			StatusCode: statusCode,
+			Status:     httpStatus,
+			Title:      p.Title,
+			Detail:     p.Detail,
+			Errors:     p.Errors,
+		}
+	}
+
+	// Fallback: unparseable body.
+	raw := strings.TrimSpace(string(body))
+	return &APIError{
+		StatusCode: statusCode,
+		Status:     httpStatus,
+		Detail:     fmt.Sprintf("server returned %s: %s", httpStatus, raw),
+	}
+}
+
 // checkStatus returns an error if the HTTP response indicates a failure.
 func checkStatus(resp *http.Response) error {
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return nil
 	}
 	body, _ := io.ReadAll(resp.Body)
-	return fmt.Errorf("server returned %s: %s", resp.Status, bytes.TrimSpace(body))
+	return ParseAPIError(bytes.TrimSpace(body), resp.Status, resp.StatusCode)
 }

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -1,0 +1,226 @@
+package cli
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIError_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		err  APIError
+		want string
+	}{
+		{
+			name: "title and detail",
+			err: APIError{
+				StatusCode: 409,
+				Status:     "409 Conflict",
+				Title:      "Conflict",
+				Detail:     `cannot delete node "test-node": 1 project(s) still assigned`,
+			},
+			want: `Conflict: cannot delete node "test-node": 1 project(s) still assigned`,
+		},
+		{
+			name: "title and validation errors",
+			err: APIError{
+				StatusCode: 400,
+				Status:     "400 Bad Request",
+				Title:      "Validation Error",
+				Errors:     []string{"name is required", "endpoint must be a valid URL"},
+			},
+			want: "Validation Error: name is required; endpoint must be a valid URL",
+		},
+		{
+			name: "title and detail take precedence over errors",
+			err: APIError{
+				StatusCode: 400,
+				Status:     "400 Bad Request",
+				Title:      "Bad Request",
+				Detail:     "invalid manifest",
+				Errors:     []string{"name is required"},
+			},
+			want: "Bad Request: invalid manifest",
+		},
+		{
+			name: "detail only (no title)",
+			err: APIError{
+				StatusCode: 500,
+				Status:     "500 Internal Server Error",
+				Detail:     "something went wrong",
+			},
+			want: "something went wrong",
+		},
+		{
+			name: "title only (no detail or errors)",
+			err: APIError{
+				StatusCode: 404,
+				Status:     "404 Not Found",
+				Title:      "Not Found",
+			},
+			want: "Not Found",
+		},
+		{
+			name: "errors only (no title)",
+			err: APIError{
+				StatusCode: 400,
+				Status:     "400 Bad Request",
+				Errors:     []string{"field x is invalid"},
+			},
+			want: "field x is invalid",
+		},
+		{
+			name: "fallback (no title, no detail, no errors)",
+			err: APIError{
+				StatusCode: 502,
+				Status:     "502 Bad Gateway",
+			},
+			want: "server returned 502 Bad Gateway",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.err.Error())
+		})
+	}
+}
+
+func TestParseAPIError_ValidProblemJSON(t *testing.T) {
+	body := []byte(`{"title":"Conflict","status":409,"type":"https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409","detail":"cannot delete node \"test-node\": 1 project(s) still assigned"}`)
+
+	apiErr := ParseAPIError(body, "409 Conflict", 409)
+
+	assert.Equal(t, 409, apiErr.StatusCode)
+	assert.Equal(t, "409 Conflict", apiErr.Status)
+	assert.Equal(t, "Conflict", apiErr.Title)
+	assert.Equal(t, `cannot delete node "test-node": 1 project(s) still assigned`, apiErr.Detail)
+	assert.Nil(t, apiErr.Errors)
+}
+
+func TestParseAPIError_ValidationErrors(t *testing.T) {
+	body := []byte(`{"title":"Validation Error","status":400,"detail":"","errors":["name is required","endpoint must be a valid URL"]}`)
+
+	apiErr := ParseAPIError(body, "400 Bad Request", 400)
+
+	assert.Equal(t, "Validation Error", apiErr.Title)
+	assert.Empty(t, apiErr.Detail)
+	assert.Equal(t, []string{"name is required", "endpoint must be a valid URL"}, apiErr.Errors)
+}
+
+func TestParseAPIError_InvalidJSON(t *testing.T) {
+	body := []byte(`this is not json`)
+
+	apiErr := ParseAPIError(body, "500 Internal Server Error", 500)
+
+	assert.Equal(t, 500, apiErr.StatusCode)
+	assert.Empty(t, apiErr.Title)
+	assert.Equal(t, "server returned 500 Internal Server Error: this is not json", apiErr.Detail)
+}
+
+func TestParseAPIError_EmptyBody(t *testing.T) {
+	apiErr := ParseAPIError([]byte{}, "404 Not Found", 404)
+
+	assert.Equal(t, 404, apiErr.StatusCode)
+	assert.Empty(t, apiErr.Title)
+	assert.Equal(t, "server returned 404 Not Found: ", apiErr.Detail)
+}
+
+func TestParseAPIError_JSONWithoutTitle(t *testing.T) {
+	// Valid JSON but missing the title field — should fall back.
+	body := []byte(`{"message":"something unexpected"}`)
+
+	apiErr := ParseAPIError(body, "500 Internal Server Error", 500)
+
+	assert.Empty(t, apiErr.Title)
+	assert.Contains(t, apiErr.Detail, "server returned 500 Internal Server Error")
+}
+
+func TestCheckStatus_Success(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.NoError(t, checkStatus(resp))
+}
+
+func TestCheckStatus_ProblemDetail(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"title":"Conflict","status":409,"detail":"resource already exists"}`))
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	checkErr := checkStatus(resp)
+	require.Error(t, checkErr)
+
+	// Should be an *APIError.
+	var apiErr *APIError
+	require.True(t, errors.As(checkErr, &apiErr))
+	assert.Equal(t, 409, apiErr.StatusCode)
+	assert.Equal(t, "Conflict", apiErr.Title)
+	assert.Equal(t, "resource already exists", apiErr.Detail)
+
+	// Error() should format cleanly.
+	assert.Equal(t, "Conflict: resource already exists", apiErr.Error())
+}
+
+func TestCheckStatus_NonJSONBody(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("upstream timeout"))
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	checkErr := checkStatus(resp)
+	require.Error(t, checkErr)
+
+	var apiErr *APIError
+	require.True(t, errors.As(checkErr, &apiErr))
+	assert.Equal(t, 502, apiErr.StatusCode)
+	assert.Contains(t, apiErr.Error(), "upstream timeout")
+}
+
+func TestCheckStatus_NotFoundProblem(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"title":"Not Found","status":404,"detail":"node \"nonexistent\" not found"}`))
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	checkErr := checkStatus(resp)
+	require.Error(t, checkErr)
+
+	var apiErr *APIError
+	require.True(t, errors.As(checkErr, &apiErr))
+	assert.Equal(t, `Not Found: node "nonexistent" not found`, apiErr.Error())
+}

--- a/internal/cli/cmd_apply.go
+++ b/internal/cli/cmd_apply.go
@@ -33,6 +33,7 @@ Examples:
   caractrl apply -f project.yaml
   cat project.yaml | caractrl apply -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			serverURL, _ := cmd.Root().PersistentFlags().GetString("server")
 			outputFmt, _ := cmd.Root().PersistentFlags().GetString("output")
 

--- a/internal/cli/cmd_delete.go
+++ b/internal/cli/cmd_delete.go
@@ -31,6 +31,7 @@ func newDeleteNodeCmd() *cobra.Command {
 		Aliases: []string{"nodes"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			serverURL, _ := cmd.Root().PersistentFlags().GetString("server")
 			name := args[0]
 
@@ -54,6 +55,7 @@ func newDeleteProjectCmd() *cobra.Command {
 		Aliases: []string{"projects"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			serverURL, _ := cmd.Root().PersistentFlags().GetString("server")
 			force, _ := cmd.Flags().GetBool("force")
 			name := args[0]

--- a/internal/cli/cmd_describe.go
+++ b/internal/cli/cmd_describe.go
@@ -45,6 +45,7 @@ func newDescribeNodeCmd() *cobra.Command {
 		Aliases: []string{"nodes"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			serverURL, _ := cmd.Root().PersistentFlags().GetString("server")
 
 			client := NewClient(serverURL)
@@ -68,6 +69,7 @@ func newDescribeProjectCmd() *cobra.Command {
 		Aliases: []string{"projects"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			serverURL, _ := cmd.Root().PersistentFlags().GetString("server")
 
 			client := NewClient(serverURL)

--- a/internal/cli/cmd_get.go
+++ b/internal/cli/cmd_get.go
@@ -34,6 +34,7 @@ func newGetNodesCmd() *cobra.Command {
 		Aliases: []string{"node"},
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			serverURL, _ := cmd.Root().PersistentFlags().GetString("server")
 			outputFmt, _ := cmd.Root().PersistentFlags().GetString("output")
 
@@ -67,6 +68,7 @@ func newGetProjectsCmd() *cobra.Command {
 		Aliases: []string{"project"},
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			serverURL, _ := cmd.Root().PersistentFlags().GetString("server")
 			outputFmt, _ := cmd.Root().PersistentFlags().GetString("output")
 

--- a/internal/cli/cmd_logs.go
+++ b/internal/cli/cmd_logs.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -54,6 +53,7 @@ Examples:
   caractrl logs my-app/web --node 192.168.1.100:9090`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			return runLogs(cmd, args, nodeAddr, follow, tail, timestamps)
 		},
 	}
@@ -131,8 +131,10 @@ func runLogs(cmd *cobra.Command, args []string, nodeAddr string, follow bool, ta
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
+		// Re-use the shared Problem Details parser via checkStatus-style logic.
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("%s", extractLogsProblemDetail(body, resp.Status))
+		apiErr := ParseAPIError(body, resp.Status, resp.StatusCode)
+		return fmt.Errorf("%s", apiErr)
 	}
 
 	// Stream the response body to stdout.
@@ -142,19 +144,4 @@ func runLogs(cmd *cobra.Command, args []string, nodeAddr string, follow bool, ta
 		return nil
 	}
 	return err
-}
-
-// extractLogsProblemDetail attempts to parse an RFC 7807 problem+json body and
-// return the human-readable detail field.  Falls back to the raw body if
-// parsing fails.
-func extractLogsProblemDetail(body []byte, httpStatus string) string {
-	var p struct {
-		Detail string `json:"detail"`
-		Title  string `json:"title"`
-	}
-	if err := json.Unmarshal(body, &p); err == nil && p.Detail != "" {
-		return p.Detail
-	}
-	// Fallback: return raw body with HTTP status.
-	return fmt.Sprintf("%s: %s", httpStatus, strings.TrimSpace(string(body)))
 }

--- a/internal/cli/cmd_portforward.go
+++ b/internal/cli/cmd_portforward.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -46,6 +45,7 @@ Examples:
   caractrl port-forward my-app/db 5432 --node 192.168.1.100:9090`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			return runPortForward(cmd, args, nodeAddr)
 		},
 	}
@@ -212,7 +212,7 @@ func handleConnection(ctx context.Context, conn net.Conn, agentAddr, project, se
 		if resp != nil {
 			body, _ := io.ReadAll(resp.Body)
 			_ = resp.Body.Close()
-			fmt.Fprintf(os.Stderr, "Error: %s\n", extractProblemDetail(body, resp.Status))
+			fmt.Fprintf(os.Stderr, "Error: %s\n", ParseAPIError(body, resp.Status, resp.StatusCode))
 		} else {
 			fmt.Fprintf(os.Stderr, "WebSocket dial failed: %v\n", err)
 		}
@@ -264,19 +264,4 @@ func handleConnection(ctx context.Context, conn net.Conn, agentAddr, project, se
 	<-done
 
 	fmt.Fprintf(os.Stderr, "Connection from %s closed\n", conn.RemoteAddr())
-}
-
-// extractProblemDetail attempts to parse an RFC 7807 problem+json body and
-// return the human-readable detail field. Falls back to the raw body if
-// parsing fails.
-func extractProblemDetail(body []byte, httpStatus string) string {
-	var p struct {
-		Detail string `json:"detail"`
-		Title  string `json:"title"`
-	}
-	if err := json.Unmarshal(body, &p); err == nil && p.Detail != "" {
-		return p.Detail
-	}
-	// Fallback: return raw body with HTTP status.
-	return fmt.Sprintf("%s: %s", httpStatus, strings.TrimSpace(string(body)))
 }


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Parse RFC 9457 Problem Details JSON in CLI error responses for clean, human-readable error messages
- Resolve issue CARA-32

When `caractl` receives an error response from `cara-server`, it now shows clean messages like:

```
Error: Conflict: cannot delete node "test-node": 1 project(s) still assigned
```

Instead of dumping raw JSON:

```
Error: delete node "test-node": server returned 409 Conflict: {"title":"Conflict","status":409,...}
```

## Additional Information

### Changes
1. **`internal/cli/client.go`** — Added exported `APIError` struct with `Error() string` that formats `Title: Detail` for problem responses, semicolon-joined validation errors, or fallback to raw body. Added `ParseAPIError()` shared constructor. Updated `checkStatus()` to return `*APIError`.

2. **`internal/cli/cmd_portforward.go`** — Removed duplicate `extractProblemDetail()`, replaced with `ParseAPIError()`.

3. **`internal/cli/cmd_logs.go`** — Removed duplicate `extractLogsProblemDetail()`, replaced with `ParseAPIError()`.

4. **`cmd/caractl/main.go`** — Set `rootCmd.SilenceErrors = true` and format error as `Error: <message>` in `main()` to fix double error printing.

5. **All command files** — Added `cmd.SilenceUsage = true` at the start of each `RunE` to suppress usage/help text on API errors.

6. **`internal/cli/client_test.go`** — Added comprehensive unit tests for `APIError.Error()` formatting and `checkStatus()` integration with `httptest` servers.

### Design decisions
- `APIError` is exported so callers can use `errors.As` to inspect server errors programmatically
- Per-command `SilenceUsage` (vs global) preserves usage output for argument validation errors from cobra's `Args` validators
- `ParseAPIError` is also exported for direct use by websocket/streaming code paths that bypass `checkStatus()`