### PR TITLE
[CARA-33] refactor: Add work queue deduplication to Controller Manager

### DIFF
--- a/internal/server/controller/manager.go
+++ b/internal/server/controller/manager.go
@@ -23,13 +23,6 @@ const (
 	defaultErrorBackoff = 5 * time.Second
 )
 
-// work is an internal reconcile request: the name of the object to process and
-// an optional delay before it should be acted upon.
-type work struct {
-	name  string
-	after time.Duration
-}
-
 // registration bundles a Controller with its runtime configuration.
 type registration struct {
 	ctrl    Controller
@@ -126,7 +119,7 @@ func (m *Manager) Start(ctx context.Context) error {
 
 	for _, reg := range m.registrations {
 		reg := reg // capture loop variable
-		queue := make(chan work, 256)
+		wq := newWorkQueue()
 
 		m.logger.Info("Starting controller",
 			zap.String("controller", reg.ctrl.Name()),
@@ -134,11 +127,11 @@ func (m *Manager) Start(ctx context.Context) error {
 		)
 
 		// Seed the queue so the controller runs at least once on startup.
-		go m.seed(ctx, reg.ctrl, queue)
+		go m.seed(ctx, reg.ctrl, wq)
 
 		// Worker pool.
 		for range reg.workers {
-			go m.runWorker(ctx, reg.ctrl, queue, errCh)
+			go m.runWorker(ctx, reg.ctrl, wq, errCh)
 		}
 	}
 
@@ -156,7 +149,7 @@ func (m *Manager) Start(ctx context.Context) error {
 // controller can drive its own scheduling (e.g. periodic list + enqueue).
 // Otherwise it logs once and returns, leaving the queue to be driven by
 // external callers (e.g. HTTP handlers via Enqueue).
-func (m *Manager) seed(ctx context.Context, ctrl Controller, queue chan<- work) {
+func (m *Manager) seed(ctx context.Context, ctrl Controller, wq *workQueue) {
 	seeder, ok := ctrl.(Seeder)
 	if !ok {
 		m.logger.Debug("Controller has no Seeder, skipping seed goroutine",
@@ -170,94 +163,62 @@ func (m *Manager) seed(ctx context.Context, ctrl Controller, queue chan<- work) 
 	)
 
 	seeder.Seed(ctx, func(name string) {
-		select {
-		case queue <- work{name: name}:
-		default:
-			m.logger.Warn("Seed enqueue dropped: work queue full",
-				zap.String("controller", ctrl.Name()),
-				zap.String("name", name),
-			)
-		}
+		wq.Enqueue(name)
 	})
 }
 
-// Enqueue adds name to queue for reconciliation after the given delay.
-// It is exported so that HTTP handlers can trigger an immediate reconcile
-// (e.g. after a user submits a new Project via the API).
-func Enqueue(queue chan<- work, name string, after time.Duration) {
-	queue <- work{name: name, after: after}
-}
-
-// runWorker pulls items from queue and calls ctrl.Reconcile until ctx is done.
-// queue is a bidirectional channel so the worker can re-enqueue keys for retry.
-func (m *Manager) runWorker(ctx context.Context, ctrl Controller, queue chan work, errCh chan<- error) {
+// runWorker pulls items from the work queue and calls ctrl.Reconcile until ctx
+// is done.
+func (m *Manager) runWorker(ctx context.Context, ctrl Controller, wq *workQueue, errCh chan<- error) {
 	log := m.logger.With(zap.String("controller", ctrl.Name()))
 	log.Debug("Worker started")
 
 	for {
-		select {
-		case <-ctx.Done():
+		name, ok := wq.Get(ctx)
+		if !ok {
 			log.Debug("Worker stopping", zap.Error(ctx.Err()))
 			return
-		case w := <-queue:
-			if w.after > 0 {
+		}
+
+		result, err := ctrl.Reconcile(ctx, name)
+
+		switch {
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			// Context cancelled mid-reconcile — not a fatal error.
+			log.Debug("Reconcile interrupted by context", zap.String("name", name))
+			return
+
+		case err != nil:
+			log.Error("Reconcile failed, will retry",
+				zap.String("name", name),
+				zap.Duration("backoff", m.errorBackoff),
+				zap.Error(err),
+			)
+			backoff := m.errorBackoff
+			go func() {
 				select {
-				case <-time.After(w.after):
+				case <-time.After(backoff):
+					wq.Enqueue(name)
 				case <-ctx.Done():
-					return
 				}
-			}
+			}()
 
-			result, err := ctrl.Reconcile(ctx, w.name)
+		case result.Requeue:
+			log.Debug("Reconcile requested requeue",
+				zap.String("name", name),
+				zap.Duration("after", m.requeueAfter),
+			)
+			requeueAfter := m.requeueAfter
+			go func() {
+				select {
+				case <-time.After(requeueAfter):
+					wq.Enqueue(name)
+				case <-ctx.Done():
+				}
+			}()
 
-			switch {
-			case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
-				// Context cancelled mid-reconcile — not a fatal error.
-				log.Debug("Reconcile interrupted by context", zap.String("name", w.name))
-				return
-
-			case err != nil:
-				log.Error("Reconcile failed, will retry",
-					zap.String("name", w.name),
-					zap.Duration("backoff", m.errorBackoff),
-					zap.Error(err),
-				)
-				name := w.name
-				backoff := m.errorBackoff
-				go func() {
-					select {
-					case <-time.After(backoff):
-						select {
-						case queue <- work{name: name}:
-						default:
-							log.Warn("Requeue dropped: work queue full", zap.String("name", name))
-						}
-					case <-ctx.Done():
-					}
-				}()
-
-			case result.Requeue:
-				log.Debug("Reconcile requested requeue",
-					zap.String("name", w.name),
-					zap.Duration("after", m.requeueAfter),
-				)
-				name := w.name
-				requeueAfter := m.requeueAfter
-				go func() {
-					select {
-					case <-time.After(requeueAfter):
-						select {
-						case queue <- work{name: name}:
-						default:
-							log.Warn("Requeue dropped: work queue full", zap.String("name", name))
-						}
-					case <-ctx.Done():
-					}
-				}()
-
-			default:
-				log.Debug("Reconcile complete", zap.String("name", w.name))
-			}
+		default:
+			log.Debug("Reconcile complete", zap.String("name", name))
 		}
 	}
 }

--- a/internal/server/controller/workqueue.go
+++ b/internal/server/controller/workqueue.go
@@ -1,0 +1,94 @@
+package controller
+
+import (
+	"context"
+	"sync"
+)
+
+// workQueue is a deduplicating work queue for reconcile keys.  It replaces the
+// plain chan-based queue to prevent the same name from being reconciled multiple
+// times in quick succession when enqueued concurrently by seeds, event-bus
+// subscribers, requeue goroutines, and HTTP handlers.
+//
+// The design is a simplified version of the dirty-set pattern used by
+// client-go/util/workqueue in Kubernetes.
+type workQueue struct {
+	mu     sync.Mutex
+	dirty  map[string]bool // names waiting to be processed
+	notify chan struct{}   // len-1 buffered signal channel
+}
+
+// newWorkQueue creates a ready-to-use workQueue.
+func newWorkQueue() *workQueue {
+	return &workQueue{
+		dirty:  make(map[string]bool),
+		notify: make(chan struct{}, 1),
+	}
+}
+
+// Enqueue adds name to the dirty set.  If the name is already present (i.e.
+// waiting to be processed), the call is a no-op — this is the deduplication
+// guarantee.  Enqueue is non-blocking and safe to call from any goroutine.
+func (wq *workQueue) Enqueue(name string) {
+	wq.mu.Lock()
+	defer wq.mu.Unlock()
+
+	if wq.dirty[name] {
+		return // already queued — deduplicate
+	}
+	wq.dirty[name] = true
+
+	// Non-blocking signal: if the channel already has a pending signal the
+	// consumer will drain it and re-check the dirty set.
+	select {
+	case wq.notify <- struct{}{}:
+	default:
+	}
+}
+
+// Get blocks until a name is available or ctx is cancelled.  It returns the
+// name and true, or ("", false) when the context is done.
+//
+// After popping one key, if the dirty set still has entries a new signal is
+// sent on the notify channel so the next Get (or the same goroutine in a loop)
+// wakes up promptly.
+func (wq *workQueue) Get(ctx context.Context) (string, bool) {
+	for {
+		select {
+		case <-ctx.Done():
+			return "", false
+		case <-wq.notify:
+			wq.mu.Lock()
+			// Pop an arbitrary key from the dirty set.
+			var name string
+			for name = range wq.dirty {
+				break
+			}
+			if name == "" {
+				// Spurious wake-up: dirty set was drained between signal
+				// and lock acquisition.
+				wq.mu.Unlock()
+				continue
+			}
+			delete(wq.dirty, name)
+
+			// Re-signal if there are more items so other workers (or the
+			// next iteration) can pick them up.
+			if len(wq.dirty) > 0 {
+				select {
+				case wq.notify <- struct{}{}:
+				default:
+				}
+			}
+			wq.mu.Unlock()
+			return name, true
+		}
+	}
+}
+
+// Len returns the number of names currently waiting in the dirty set.
+func (wq *workQueue) Len() int {
+	wq.mu.Lock()
+	defer wq.mu.Unlock()
+	return len(wq.dirty)
+}

--- a/internal/server/controller/workqueue_test.go
+++ b/internal/server/controller/workqueue_test.go
@@ -1,0 +1,160 @@
+package controller
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWorkQueue_DeduplicatesBeforeGet enqueues the same name N times before
+// any Get call and verifies the name is returned exactly once.
+func TestWorkQueue_DeduplicatesBeforeGet(t *testing.T) {
+	t.Helper()
+
+	wq := newWorkQueue()
+
+	const name = "my-node"
+	const N = 10
+
+	for range N {
+		wq.Enqueue(name)
+	}
+
+	// The dirty set should contain exactly one entry.
+	require.Equal(t, 1, wq.Len(), "dirty set should have exactly 1 entry after N duplicate enqueues")
+
+	// Get should return the name exactly once.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	got, ok := wq.Get(ctx)
+	require.True(t, ok, "Get should succeed")
+	assert.Equal(t, name, got)
+
+	// After the Get, the queue should be empty.
+	assert.Equal(t, 0, wq.Len(), "dirty set should be empty after Get")
+
+	// A second Get should block until context cancels (no more items).
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel2()
+
+	_, ok = wq.Get(ctx2)
+	assert.False(t, ok, "second Get should return false (context cancelled, no items)")
+}
+
+// TestWorkQueue_DeduplicatesDuringRequeue simulates the scenario where a name
+// is re-enqueued (e.g. by a requeue goroutine after a backoff sleep) while the
+// same name is already in the dirty set.  The name should only be returned once
+// by Get.
+func TestWorkQueue_DeduplicatesDuringRequeue(t *testing.T) {
+	t.Helper()
+
+	wq := newWorkQueue()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	const name = "my-project"
+
+	// Simulate: seed enqueues the name.
+	wq.Enqueue(name)
+
+	// Simulate: a requeue goroutine fires and tries to enqueue the same name
+	// after a short delay, while the original is still in the dirty set.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(10 * time.Millisecond)
+		wq.Enqueue(name) // should be a no-op (deduplicated)
+	}()
+
+	// Wait for the requeue goroutine to run.
+	wg.Wait()
+
+	// The dirty set should still have exactly one entry.
+	require.Equal(t, 1, wq.Len(), "dirty set should have 1 entry after dedup requeue")
+
+	// Get returns the name once.
+	got, ok := wq.Get(ctx)
+	require.True(t, ok)
+	assert.Equal(t, name, got)
+	assert.Equal(t, 0, wq.Len())
+
+	// No more items.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel2()
+	_, ok = wq.Get(ctx2)
+	assert.False(t, ok, "no more items expected")
+}
+
+// TestWorkQueue_GetBlocksUntilEnqueue verifies that Get blocks when the queue
+// is empty and returns promptly once a name is enqueued.
+func TestWorkQueue_GetBlocksUntilEnqueue(t *testing.T) {
+	t.Helper()
+
+	wq := newWorkQueue()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	const name = "delayed-item"
+
+	// Enqueue after a short delay.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		wq.Enqueue(name)
+	}()
+
+	got, ok := wq.Get(ctx)
+	require.True(t, ok, "Get should succeed after enqueue")
+	assert.Equal(t, name, got)
+}
+
+// TestWorkQueue_GetContextCancelled verifies that Get returns ("", false) when
+// the context is cancelled while waiting.
+func TestWorkQueue_GetContextCancelled(t *testing.T) {
+	t.Helper()
+
+	wq := newWorkQueue()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel immediately.
+	cancel()
+
+	got, ok := wq.Get(ctx)
+	assert.False(t, ok, "Get should return false on cancelled context")
+	assert.Empty(t, got)
+}
+
+// TestWorkQueue_MultipleNames verifies that multiple distinct names are all
+// returned by Get (order is non-deterministic since the dirty set is a map).
+func TestWorkQueue_MultipleNames(t *testing.T) {
+	t.Helper()
+
+	wq := newWorkQueue()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	names := []string{"alpha", "beta", "gamma"}
+	for _, n := range names {
+		wq.Enqueue(n)
+	}
+
+	require.Equal(t, 3, wq.Len())
+
+	var got []string
+	for range names {
+		name, ok := wq.Get(ctx)
+		require.True(t, ok)
+		got = append(got, name)
+	}
+
+	sort.Strings(got)
+	sort.Strings(names)
+	assert.Equal(t, names, got, "all distinct names should be returned exactly once")
+	assert.Equal(t, 0, wq.Len())
+}


### PR DESCRIPTION
## Type of changes
- Refactor

## Purpose
- Replace the plain `chan work` (capacity 256) in the Controller Manager with a deduplicating `workQueue` type
- Resolve issue CARA-33

The Controller Manager's work queue previously had no deduplication — the same key could appear multiple times when enqueued concurrently by seeds, event bus, requeue goroutines, and HTTP handlers. This caused redundant reconciliation work that grows linearly with node/project count.

The new `workQueue` uses a mutex + dirty-set pattern (inspired by Kubernetes `client-go/util/workqueue`) to guarantee each name appears at most once in the queue.

## Additional Information

### Design decisions
- `workQueue` is **unexported** — internal to the controller package. Future HTTP handler integration can go through an exported Manager method.
- `Enqueue` is a **method** on `*workQueue` (not a package-level function). The old exported `Enqueue(chan<- work, ...)` had zero callers and was removed.
- The `work` struct and its `after` field are removed entirely. Delayed requeue is handled by the goroutine sleeping before calling `wq.Enqueue()`.
- The `select/default` drop pattern in `seed()` is no longer needed since `Enqueue` is non-blocking by design.

### Files changed
- `internal/server/controller/workqueue.go` — new `workQueue` type with `Enqueue`, `Get`, `Len`
- `internal/server/controller/manager.go` — updated `Start`, `seed`, `runWorker` to use `*workQueue`
- `internal/server/controller/workqueue_test.go` — unit tests for deduplication, blocking Get, context cancellation, multiple names

### Verification
- `go build ./...` ✓
- `make test` ✓
- `make test-integration` ✓