### PR TITLE
[CARA-34] fix: Only publish node.updated event on actual state change

### DIFF
--- a/internal/server/controller/node_health.go
+++ b/internal/server/controller/node_health.go
@@ -119,11 +119,8 @@ func (c *NodeHealthController) Reconcile(ctx context.Context, name string) (Resu
 		); err != nil {
 			return Result{}, err
 		}
-		// Notify ProjectReschedulerController (and any other subscribers) that
-		// this node's state changed so they can react immediately.
-		if c.bus != nil {
-			c.bus.Publish(event.TopicNodeUpdated, name)
-		}
+		// The store layer now publishes TopicNodeUpdated when the phase
+		// actually changes, so an explicit publish here is unnecessary.
 
 	case age <= NodeHeartbeatTimeout && snap.State == v1.NodeStateNotReady:
 		log.Info("Node heartbeat recovered, marking Ready",

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -339,25 +339,38 @@ func (s *Store) DeleteNode(ctx context.Context, name string) error {
 // UpdateNodeStatus implements store.NodeStore.
 // Only the status column (and the promoted phase column) are written; spec is
 // untouched, so concurrent API-server spec updates are not clobbered.
+//
+// A TopicNodeUpdated event is published only when the node's phase actually
+// changes (e.g. Ready→NotReady), not on every heartbeat refresh.
 func (s *Store) UpdateNodeStatus(ctx context.Context, name string, status v1.NodeStatus) error {
 	raw, err := json.Marshal(status)
 	if err != nil {
 		return fmt.Errorf("postgres: marshal node status: %w", err)
 	}
 
-	tag, err := s.pool.Exec(ctx, `
+	// Use a CTE to atomically capture the old phase before the UPDATE.
+	// This avoids a separate SELECT and any TOCTOU race conditions.
+	var oldPhase string
+	err = s.pool.QueryRow(ctx, `
+		WITH old AS (
+			SELECT phase FROM resources WHERE kind = $4 AND name = $5
+		)
 		UPDATE resources
 		SET phase = $1, status = $2, updated_at = $3
-		WHERE kind = $4 AND name = $5`,
+		WHERE kind = $4 AND name = $5
+		RETURNING (SELECT phase FROM old) AS old_phase`,
 		string(status.State), raw, time.Now().UTC(), kindNode, name,
-	)
+	).Scan(&oldPhase)
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: node %q", store.ErrNotFound, name)
+		}
 		return fmt.Errorf("postgres: update node status %q: %w", name, err)
 	}
-	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("%w: node %q", store.ErrNotFound, name)
+
+	if oldPhase != string(status.State) {
+		s.publish(event.TopicNodeUpdated, name)
 	}
-	s.publish(event.TopicNodeUpdated, name)
 	return nil
 }
 

--- a/test/integration/controller/store_event_test.go
+++ b/test/integration/controller/store_event_test.go
@@ -1,0 +1,127 @@
+//go:build e2e
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "NYCU-SDC/caravanserai/api/v1"
+	"NYCU-SDC/caravanserai/internal/event"
+	pgstore "NYCU-SDC/caravanserai/internal/store/postgres"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateNodeStatusOnlyPublishesOnPhaseChange validates that
+// UpdateNodeStatus publishes a TopicNodeUpdated event only when the node's
+// phase (state) actually changes, not on every call.
+//
+// Acceptance criteria covered:
+//   - Same-state calls produce no event after the first
+//   - State transitions (Ready→NotReady, NotReady→Ready) produce events
+func TestUpdateNodeStatusOnlyPublishesOnPhaseChange(t *testing.T) {
+	ctx := context.Background()
+
+	bus := event.New(shared.logger, 256)
+	store, err := pgstore.New(ctx, shared.databaseURL, shared.logger, bus)
+	require.NoError(t, err, "pgstore.New")
+	defer store.Close()
+
+	// Clean slate.
+	_, err = shared.pool.Exec(ctx, "TRUNCATE TABLE resources")
+	require.NoError(t, err, "truncate")
+
+	// Subscribe to node.updated events before any operations.
+	sub := bus.Subscribe(event.TopicNodeUpdated)
+
+	// Create a node in Ready state.
+	node := &v1.Node{
+		TypeMeta:   v1.TypeMeta{APIVersion: v1.APIVersion, Kind: "Node"},
+		ObjectMeta: v1.ObjectMeta{Name: "event-test-node"},
+		Spec:       v1.NodeSpec{Hostname: "event-test-node"},
+		Status: v1.NodeStatus{
+			State:         v1.NodeStateReady,
+			LastHeartbeat: time.Now().UTC(),
+		},
+	}
+	require.NoError(t, store.CreateNode(ctx, node))
+
+	// Drain the node.created event (CreateNode does not publish
+	// TopicNodeUpdated, but let's be safe).
+	drainEvents(sub, 100*time.Millisecond)
+
+	// --- Test 1: First UpdateNodeStatus with same state → event (phase is
+	// written from the initial CreateNode value, but the CTE compares old
+	// vs. new; since CreateNode already set phase="Ready" and we're
+	// updating with State=Ready, old==new, so NO event should fire).
+	readyStatus := v1.NodeStatus{
+		State:         v1.NodeStateReady,
+		LastHeartbeat: time.Now().UTC(),
+	}
+	require.NoError(t, store.UpdateNodeStatus(ctx, "event-test-node", readyStatus))
+
+	events := collectEvents(sub, 200*time.Millisecond)
+	assert.Empty(t, events, "same-state UpdateNodeStatus (Ready→Ready) should not publish an event")
+
+	// --- Test 2: Second call with same state → still no event.
+	readyStatus.LastHeartbeat = time.Now().UTC()
+	require.NoError(t, store.UpdateNodeStatus(ctx, "event-test-node", readyStatus))
+
+	events = collectEvents(sub, 200*time.Millisecond)
+	assert.Empty(t, events, "repeated same-state UpdateNodeStatus should not publish an event")
+
+	// --- Test 3: Transition Ready → NotReady → event published.
+	notReadyStatus := v1.NodeStatus{
+		State:         v1.NodeStateNotReady,
+		LastHeartbeat: time.Now().UTC(),
+	}
+	require.NoError(t, store.UpdateNodeStatus(ctx, "event-test-node", notReadyStatus))
+
+	events = collectEvents(sub, 200*time.Millisecond)
+	require.Len(t, events, 1, "Ready→NotReady transition should publish exactly one event")
+	assert.Equal(t, "event-test-node", events[0].Name)
+
+	// --- Test 4: Same NotReady state again → no event.
+	notReadyStatus.LastHeartbeat = time.Now().UTC()
+	require.NoError(t, store.UpdateNodeStatus(ctx, "event-test-node", notReadyStatus))
+
+	events = collectEvents(sub, 200*time.Millisecond)
+	assert.Empty(t, events, "same-state UpdateNodeStatus (NotReady→NotReady) should not publish an event")
+
+	// --- Test 5: Transition NotReady → Ready → event published.
+	readyStatus.LastHeartbeat = time.Now().UTC()
+	require.NoError(t, store.UpdateNodeStatus(ctx, "event-test-node", readyStatus))
+
+	events = collectEvents(sub, 200*time.Millisecond)
+	require.Len(t, events, 1, "NotReady→Ready transition should publish exactly one event")
+	assert.Equal(t, "event-test-node", events[0].Name)
+}
+
+// drainEvents reads and discards all events from the channel until the timeout
+// elapses with no new events.
+func drainEvents(ch event.Handler, timeout time.Duration) {
+	for {
+		select {
+		case <-ch:
+		case <-time.After(timeout):
+			return
+		}
+	}
+}
+
+// collectEvents reads events from the channel until the timeout elapses with
+// no new events.
+func collectEvents(ch event.Handler, timeout time.Duration) []event.Event {
+	var events []event.Event
+	for {
+		select {
+		case e := <-ch:
+			events = append(events, e)
+		case <-time.After(timeout):
+			return events
+		}
+	}
+}


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Eliminate wasteful no-op reconcile cycles caused by heartbeat-driven `TopicNodeUpdated` events
- Resolve issue CARA-34

Every agent heartbeat (every 10–30s per node) calls `UpdateNodeStatus`, which unconditionally published a `TopicNodeUpdated` event. This triggered the `ProjectReschedulerController` to do pointless work thousands of times per hour — fetching the node, seeing it's still Ready, and returning.

This PR makes `UpdateNodeStatus` only publish `TopicNodeUpdated` when the node's phase actually changes (e.g. Ready→NotReady), not on every heartbeat refresh.

## Additional Information

### Approach
- Uses a PostgreSQL CTE to atomically capture the old `phase` before the UPDATE and return it via `RETURNING`. This avoids a separate SELECT and any TOCTOU race conditions.
- Changed `Exec` to `QueryRow` + `Scan` to read the old phase; `ErrNotFound` detection adapted from `RowsAffected() == 0` to `pgx.ErrNoRows`.
- Removed the redundant manual `bus.Publish(TopicNodeUpdated)` in `NodeHealthController.Reconcile` (node_health.go:124-126). Since `SetNodeState` calls `UpdateNodeStatus` internally, the store layer now handles event publishing on state transitions. The work-queue deduplication from CARA-33 provides additional safety.
- `UpdateNodeSpec` continues to publish `TopicNodeUpdated` unconditionally — spec changes (e.g. cordon/uncordon) should always notify subscribers.

### Files changed
- `internal/store/postgres/store.go` — CTE-based conditional publish in `UpdateNodeStatus`
- `internal/server/controller/node_health.go` — removed redundant manual `bus.Publish`
- `test/integration/controller/store_event_test.go` — new integration test validating conditional event publishing (5 scenarios: Ready→Ready, repeated same-state, Ready→NotReady, NotReady→NotReady, NotReady→Ready)