### PR TITLE
[CARA-36] feat: Add NodeInfo struct and pressure condition types to API

### DIFF
--- a/api/v1/condition.go
+++ b/api/v1/condition.go
@@ -7,6 +7,14 @@
 //	  heartbeat state changes.  Status=True means the agent is healthy;
 //	  Status=False means the heartbeat timed out.
 //
+//	  ConditionTypeDiskPressure — set by NodeConditionController based on
+//	  the Agent's reported Capacity and Allocatable values.  Status=True
+//	  means the node's allocatable disk is below 15% of capacity.
+//
+//	  ConditionTypeMemoryPressure — set by NodeConditionController based on
+//	  the Agent's reported Capacity and Allocatable values.  Status=True
+//	  means the node's allocatable memory is below 10% of capacity.
+//
 //	Project (project_types.go)
 //	  ConditionTypePhase — updated on every lifecycle phase transition to carry
 //	  the machine-readable Reason and human-readable Message.  Status is always
@@ -58,6 +66,16 @@ const (
 	// ConditionTypeNotReadyAt records the timestamp at which the rescheduler
 	// first observed a Running project on a NotReady node.
 	ConditionTypeNotReadyAt ConditionType = "NotReadyAt"
+
+	// ConditionTypeDiskPressure indicates whether the node's disk usage is
+	// approaching capacity. Set by the NodeConditionController based on
+	// the Agent's reported Capacity and Allocatable values.
+	ConditionTypeDiskPressure ConditionType = "DiskPressure"
+
+	// ConditionTypeMemoryPressure indicates whether the node's memory usage
+	// is approaching capacity. Set by the NodeConditionController based on
+	// the Agent's reported Capacity and Allocatable values.
+	ConditionTypeMemoryPressure ConditionType = "MemoryPressure"
 )
 
 // Condition describes a single observable aspect of a resource's state.

--- a/api/v1/node_types.go
+++ b/api/v1/node_types.go
@@ -82,6 +82,18 @@ func (s NodeState) IsValid() bool {
 	}
 }
 
+// NodeInfo contains static system information reported by the Agent at startup.
+type NodeInfo struct {
+	// KernelVersion is the Linux kernel version (e.g. "5.15.0-84-generic").
+	KernelVersion string `json:"kernelVersion,omitempty" yaml:"kernelVersion,omitempty"`
+
+	// OSImage is the OS distribution description (e.g. "Ubuntu 22.04.3 LTS").
+	OSImage string `json:"osImage,omitempty" yaml:"osImage,omitempty"`
+
+	// AgentVersion is the cara-agent build version (e.g. "v1.2.0").
+	AgentVersion string `json:"agentVersion,omitempty" yaml:"agentVersion,omitempty"`
+}
+
 // NodeSpec contains the administrator-declared configuration of a Node.
 type NodeSpec struct {
 	// Hostname is the OS-level hostname of the machine.
@@ -109,6 +121,9 @@ type NodeStatus struct {
 	// by the Agent. The Scheduler subtracts running-Project usage to derive
 	// the effective available headroom.
 	Allocatable ResourceList `json:"allocatable,omitempty" yaml:"allocatable,omitempty"`
+
+	// Info contains static system information reported once at Agent startup.
+	Info NodeInfo `json:"info,omitempty" yaml:"info,omitempty"`
 
 	// LastHeartbeat is the timestamp of the most recent heartbeat received
 	// from the Agent. The NodeController uses this to detect timeouts.

--- a/internal/cli/cmd_describe.go
+++ b/internal/cli/cmd_describe.go
@@ -111,6 +111,13 @@ func describeNode(w io.Writer, node *v1.Node) {
 	printField(w, "  State", stringOrNone(string(node.Status.State)))
 	printField(w, "  Last Heartbeat", formatTimestamp(node.Status.LastHeartbeat))
 
+	// Info
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Info:")
+	printField(w, "  Kernel Version", stringOrNone(node.Status.Info.KernelVersion))
+	printField(w, "  OS Image", stringOrNone(node.Status.Info.OSImage))
+	printField(w, "  Agent Version", stringOrNone(node.Status.Info.AgentVersion))
+
 	// Network
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Network:")

--- a/internal/cli/cmd_describe_test.go
+++ b/internal/cli/cmd_describe_test.go
@@ -90,6 +90,10 @@ var describeNodeCoveredFields = newStringSet(
 	"Status.Conditions",
 	"Status.Capacity",
 	"Status.Allocatable",
+	// Status.Info
+	"Status.Info.KernelVersion",
+	"Status.Info.OSImage",
+	"Status.Info.AgentVersion",
 	// Status.Network
 	"Status.Network.IP",
 	"Status.Network.DNSName",

--- a/schemas/node.json
+++ b/schemas/node.json
@@ -78,6 +78,25 @@
       "title": "Node",
       "description": "Node represents a physical or virtual machine managed by a Caravanserai Agent."
     },
+    "NodeInfo": {
+      "properties": {
+        "kernelVersion": {
+          "type": "string",
+          "description": "KernelVersion is the Linux kernel version (e.g. \"5.15.0-84-generic\")."
+        },
+        "osImage": {
+          "type": "string",
+          "description": "OSImage is the OS distribution description (e.g. \"Ubuntu 22.04.3 LTS\")."
+        },
+        "agentVersion": {
+          "type": "string",
+          "description": "AgentVersion is the cara-agent build version (e.g. \"v1.2.0\")."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "NodeInfo contains static system information reported by the Agent at startup."
+    },
     "NodeNetworkStatus": {
       "properties": {
         "ip": {
@@ -146,6 +165,10 @@
         "allocatable": {
           "$ref": "#/$defs/ResourceList",
           "description": "Allocatable is Capacity minus system-reserved amounts, also reported\nby the Agent. The Scheduler subtracts running-Project usage to derive\nthe effective available headroom."
+        },
+        "info": {
+          "$ref": "#/$defs/NodeInfo",
+          "description": "Info contains static system information reported once at Agent startup."
         },
         "lastHeartbeat": {
           "type": "string",


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add `NodeInfo` struct with `KernelVersion`, `OSImage`, `AgentVersion` to `api/v1/node_types.go`
- Add `Info NodeInfo` field to `NodeStatus` (after `Allocatable`, before `LastHeartbeat`)
- Define `ConditionTypeDiskPressure` and `ConditionTypeMemoryPressure` in `api/v1/condition.go`
- Update package doc comment to document new Node condition types
- Add NodeInfo display to `caractl describe node` output
- Part of CARA-35: Report Node system info (CPU, memory, disk) and pressure conditions

## Additional Information

This is the first subtask of CARA-35, establishing the API types that downstream subtasks depend on:
- **CARA-37**: sysinfo package (will populate `NodeInfo` fields)
- **CARA-38**: Agent heartbeat expansion (will send `Info` + `Capacity` + `Allocatable`)
- **CARA-39**: Server heartbeat handler (will merge `Info` field)
- **CARA-40**: NodeConditionController (will use `DiskPressure`/`MemoryPressure` constants)
- **CARA-41**: CLI describe node (display already added here due to field coverage test)

`tailscaleVersion` is intentionally deferred — depends on Headscale integration (CARA-30).

The `caractl describe node` Info section was added in this PR (originally scoped for CARA-41) because the existing `TestDescribeNodeFieldCoverage` test enforces that all Node struct fields have corresponding describe output.